### PR TITLE
 Fix incorrect reference to member output_dir

### DIFF
--- a/python-sdk/nuscenes/eval/nuscenes_eval.py
+++ b/python-sdk/nuscenes/eval/nuscenes_eval.py
@@ -284,7 +284,7 @@ class NuScenesEval:
             'weighted_sum': weighted_sum,
             'eval_time': eval_time
         }
-        with open(os.path.join(output_dir, 'metrics.json'), 'w') as f:
+        with open(os.path.join(self.output_dir, 'metrics.json'), 'w') as f:
             json.dump(all_metrics, f, indent=2)
 
         return all_metrics


### PR DESCRIPTION
Doing the same here, so that run_eval() works even when not called as __main__. Now member is used instead of global var.