### PR TITLE
Cleaned up map API. Note breaking changes.

### DIFF
--- a/python-sdk/nuscenes/eval/nuscenes_eval.py
+++ b/python-sdk/nuscenes/eval/nuscenes_eval.py
@@ -441,6 +441,7 @@ class NuScenesEval:
         rec_interp = np.linspace(score_range[0], score_range[1], thresh_count)
         threshold_inds = np.searchsorted(rec, rec_interp, side='left').astype(np.float32)
         threshold_inds[threshold_inds == len(rec)] = np.nan  # Mark unachieved recall values as such.
+        assert np.nanmax(threshold_inds) < len(sortind)  # Check that threshold indices are not out of bounds.
         metrics['threshold_inds'] = threshold_inds
 
         # Interpolation of precisions to the nearest lower recall threshold.

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1045,7 +1045,7 @@ class NuScenesExplorer:
 
         # Plot.
         _, ax = plt.subplots(1, 1, figsize=(10, 10))
-        ax.imshow(map_mask.mask)
+        ax.imshow(map_mask.mask())
         title = 'Number of ego poses within {}m in {}'.format(close_dist, log_location)
         ax.set_title(title, color='w')
         sc = ax.scatter(map_poses[:, 0], map_poses[:, 1], s=10, c=close_poses)

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -36,12 +36,17 @@ class NuScenes:
     Database class for nuScenes to help query and retrieve information from the database.
     """
 
-    def __init__(self, version: str='v0.4', dataroot: str='/data/nuscenes', verbose: bool=True):
+    def __init__(self,
+                 version: str = 'v0.4',
+                 dataroot: str = '/data/nuscenes',
+                 verbose: bool = True,
+                 map_resolution: float = 0.1):
         """
         Loads database and creates reverse indexes and shortcuts.
         :param version: Version to load (e.g. "v0.2", ...).
         :param dataroot: Path to the tables and data.
         :param verbose: Whether to print status messages during load.
+        :param map_resolution: Resolution of maps (meters).
         """
         if version not in ['v0.2', 'v0.3', 'v0.4', 'v1.0']:
             raise ValueError('Invalid DB version: {}'.format(version))
@@ -74,7 +79,7 @@ class NuScenes:
 
         # Initialize map mask for each map record.
         for map_record in self.map:
-            map_record['mask'] = MapMask(osp.join(self.dataroot, map_record['filename']))
+            map_record['mask'] = MapMask(osp.join(self.dataroot, map_record['filename']), resolution=map_resolution)
 
         if verbose:
             for table in self.table_names:
@@ -399,8 +404,8 @@ class NuScenes:
     def render_scene_channel(self, scene_token: str, channel: str='CAM_FRONT', imsize: Tuple[float, float]=(640, 360)):
         self.explorer.render_scene_channel(scene_token, channel=channel, imsize=imsize)
 
-    def render_egoposes_on_map(self, log_location: str, scene_tokens: List=None, demo_ss_factor: float=2.0) -> None:
-        self.explorer.render_egoposes_on_map(log_location, scene_tokens, demo_ss_factor)
+    def render_egoposes_on_map(self, log_location: str, scene_tokens: List = None) -> None:
+        self.explorer.render_egoposes_on_map(log_location, scene_tokens)
 
 
 class NuScenesExplorer:
@@ -987,19 +992,16 @@ class NuScenesExplorer:
 
         cv2.destroyAllWindows()
 
-    def render_egoposes_on_map(self, log_location: str, scene_tokens: List=None, demo_ss_factor: float=2.0) \
-            -> None:
+    def render_egoposes_on_map(self, log_location: str, scene_tokens: List = None) -> None:
         """
         Renders ego poses a the map. These can be filtered by location or scene.
         :param log_location: Name of the location, e.g. "singapore-onenorth", "singapore-hollandvillage",
                              "singapore-queenstown' and "boston-seaport".
         :param scene_tokens: Optional list of scene tokens.
-        :param demo_ss_factor: Subsampling factor for rendering the map.
         """
 
         # Settings
         close_dist = 100
-        pixel_to_meter = 0.1
 
         # Get logs by location
         log_tokens = [l['token'] for l in self.nusc.log if l['location'] == log_location]
@@ -1032,29 +1034,21 @@ class NuScenesExplorer:
                 sample_data_record = self.nusc.get('sample_data', sample_record['data']['LIDAR_TOP'])
                 pose_record = self.nusc.get('ego_pose', sample_data_record['ego_pose_token'])
 
-                # Recover the ego pose. A 1 is added at the end to make it homogenous coordinates.
-                pose = np.array(pose_record['translation'] + [1])
-
-                # Calculate the pose on the map.
-                map_pose = np.dot(map_mask.transform_matrix, pose)
-                map_pose = map_pose[:2]
-                map_poses.append(map_pose)
+                # Calculate the pose on the map and append
+                map_poses.append(np.concatenate(
+                    map_mask.to_map_coord(pose_record['translation'][0], pose_record['translation'][1])))
 
         # Compute number of close ego poses.
         map_poses = np.vstack(map_poses)
-        dists = sklearn.metrics.pairwise.euclidean_distances(map_poses * pixel_to_meter)
+        dists = sklearn.metrics.pairwise.euclidean_distances(map_poses * map_mask.resolution)
         close_poses = np.sum(dists < close_dist, axis=0)
 
         # Plot.
         _, ax = plt.subplots(1, 1, figsize=(10, 10))
-        mask = Image.fromarray(map_mask.mask)
-        size_x = int(mask.size[0] / demo_ss_factor)
-        size_y = int(mask.size[1] / demo_ss_factor)
-        mask_small = np.asarray(mask.resize((size_x, size_y), resample=Image.NEAREST))
-        ax.imshow(mask_small)
+        ax.imshow(map_mask.mask)
         title = 'Number of ego poses within {}m in {}'.format(close_dist, log_location)
         ax.set_title(title, color='w')
-        sc = ax.scatter(map_poses[:, 0] / demo_ss_factor, map_poses[:, 1] / demo_ss_factor, s=10, c=close_poses)
+        sc = ax.scatter(map_poses[:, 0], map_poses[:, 1], s=10, c=close_poses)
         color_bar = plt.colorbar(sc, fraction=0.025, pad=0.04)
         plt.rcParams['figure.facecolor'] = 'black'
         color_bar_ticklabels = plt.getp(color_bar.ax.axes, 'yticklabels')

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1036,7 +1036,7 @@ class NuScenesExplorer:
 
                 # Calculate the pose on the map and append
                 map_poses.append(np.concatenate(
-                    map_mask.to_map_coord(pose_record['translation'][0], pose_record['translation'][1])))
+                    map_mask.to_pixel_coords(pose_record['translation'][0], pose_record['translation'][1])))
 
         # Compute number of close ego poses.
         map_poses = np.vstack(map_poses)

--- a/python-sdk/nuscenes/utils/map_mask.py
+++ b/python-sdk/nuscenes/utils/map_mask.py
@@ -40,7 +40,7 @@ class MapMask:
         px, py = self.to_map_coord(x, y)
 
         on_mask = np.ones(px.size, dtype=np.bool)
-        this_mask = self.dilated_mask(dilation)
+        this_mask = self.mask(dilation)
 
         on_mask[px < 0] = False
         on_mask[px >= this_mask.shape[1]] = False
@@ -82,7 +82,7 @@ class MapMask:
                          [0, 0, 1, 0], [0, 0, 0, 1]])
 
     @cached(cache=LRUCache(maxsize=3))
-    def dilated_mask(self, dilation: float = 2.0) -> np.ndarray:
+    def mask(self, dilation: float = 2.0) -> np.ndarray:
         """
         Sometimes it is convenient to dilate the drivable surface mask a bit. This method does that for you.
         :param dilation: <float>. Dilation in meters.

--- a/python-sdk/nuscenes/utils/map_mask.py
+++ b/python-sdk/nuscenes/utils/map_mask.py
@@ -39,10 +39,9 @@ class MapMask:
         if dilation == 0:
             return self._base_mask
         else:
-            distance_mask = cv2.distanceTransform((self.foreground - self._base_mask).astype(np.uint8), cv2.DIST_L2,
-                                                  5)
+            distance_mask = cv2.distanceTransform((self.foreground - self._base_mask).astype(np.uint8), cv2.DIST_L2, 5)
             distance_mask = (distance_mask * self.resolution).astype(np.float32)
-            return (distance_mask < dilation).astype(np.uint8) * self.foreground
+            return (distance_mask <= dilation).astype(np.uint8) * self.foreground
 
     @property
     def transform_matrix(self) -> np.ndarray:
@@ -62,7 +61,7 @@ class MapMask:
         :param dilation: <float>. Optional dilation of map mask.
         :return: <np.bool: x.shape>. Whether the points are on the mask.
         """
-        px, py = self.to_map_coord(x, y)
+        px, py = self.to_pixel_coords(x, y)
 
         on_mask = np.ones(px.size, dtype=np.bool)
         this_mask = self.mask(dilation)
@@ -76,9 +75,9 @@ class MapMask:
 
         return on_mask
 
-    def to_map_coord(self, x, y) -> Tuple[np.ndarray, np.ndarray]:
+    def to_pixel_coords(self, x, y) -> Tuple[np.ndarray, np.ndarray]:
         """
-        Maps x, y location in global coordinates to the map coordinates.
+        Maps x, y location in global map coordinates to the map image coordinates.
         :param x: Global x coordinates. Can be a scalar, list or a numpy array of x coordinates.
         :param y: Global y coordinates. Can be a scalar, list or a numpy array of x coordinates.
         :return: (px <np.uint8: x.shape>, py <np.uint8: y.shape>). Pixel coordinates in map.

--- a/python-sdk/nuscenes/utils/map_mask.py
+++ b/python-sdk/nuscenes/utils/map_mask.py
@@ -1,9 +1,11 @@
 # nuScenes dev-kit.
-# Code written by Qiang Xu, 2018.
+# Code written by Qiang Xu, Oscar Beijbom, 2018.
 # Licensed under the Creative Commons [see licence.txt]
 
 import os.path as osp
 from typing import Tuple
+
+from cachetools import cached, LRUCache
 
 import numpy as np
 import cv2
@@ -14,33 +16,60 @@ Image.MAX_IMAGE_PIXELS = 400000 * 400000
 
 
 class MapMask:
-    def __init__(self, img_file: str):
+    def __init__(self, img_file: str, resolution: float = 0.1):
         """
         Init a map mask object that contains the semantic prior (drivable surface and sidewalks) mask.
         :param img_file: File path to map png file.
+        :param resolution: Map resolution in meters.
         """
         assert osp.exists(img_file), 'map mask {} does not exist'.format(img_file)
+        assert resolution >= 0.1, "Only supports down to 0.1 meter resolution."
         self.img_file = img_file
-        self.precision = 0.1    # Precision in meters.
+        self.resolution = resolution
         self.foreground = 255
         self.background = 0
-        self._mask = None   # Binary map mask (lazy load).
-        self._transf_matrix = None  # Transformation matrix from global coords to map coords (lazy load).
 
-    @property
-    def mask(self) -> np.ndarray:
+    def is_on_mask(self, x, y, dilation=0) -> np.array:
         """
-        Create binary mask from the png file.
-        :return: <np.int8: image.height, image.width>. The binary mask.
+        Determine whether the given coordinates are on the (optionally dilated) map mask.
+        :param x: Global x coordinates. Can be a scalar, list or a numpy array of x coordinates.
+        :param y: Global y coordinates. Can be a scalar, list or a numpy array of x coordinates.
+        :param dilation: <float>. Optional dilation of map mask.
+        :return: <np.bool: x.shape>. Whether the points are on the mask.
         """
-        if self._mask is None:
-            # Pillow allows us to specify the maximum image size above, whereas this is more difficult in OpenCV.
-            img = Image.open(self.img_file).convert('L')
-            self._mask = np.array(img)
-            self._mask[self._mask < 225] = self.background
-            self._mask[self._mask >= 225] = self.foreground
+        px, py = self.to_map_coord(x, y)
 
-        return self._mask
+        on_mask = np.ones(px.size, dtype=np.bool)
+        this_mask = self.dilated_mask(dilation)
+
+        on_mask[px < 0] = False
+        on_mask[px >= this_mask.shape[1]] = False
+        on_mask[py < 0] = False
+        on_mask[py >= this_mask.shape[0]] = False
+
+        on_mask[on_mask] = this_mask[py[on_mask], px[on_mask]] == self.foreground
+
+        return on_mask
+
+    def to_map_coord(self, x, y) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Maps x, y location in global coordinates to the map coordinates.
+        :param x: Global x coordinates. Can be a scalar, list or a numpy array of x coordinates.
+        :param y: Global y coordinates. Can be a scalar, list or a numpy array of x coordinates.
+        :return: (px <np.uint8: x.shape>, py <np.uint8: y.shape>). Pixel coordinates in map.
+        """
+        x = np.array(x)
+        y = np.array(y)
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
+
+        assert x.shape == y.shape
+        assert x.ndim == y.ndim == 1
+
+        pts = np.stack([x, y, np.zeros(x.shape), np.ones(x.shape)])
+        pixel_coords = np.round(np.dot(self.transform_matrix, pts)).astype(np.int32)
+
+        return pixel_coords[0, :], pixel_coords[1, :]
 
     @property
     def transform_matrix(self) -> np.ndarray:
@@ -48,75 +77,40 @@ class MapMask:
         Generate transform matrix for this map mask.
         :return: <np.array: 4, 4>. The transformation matrix.
         """
-        if self._transf_matrix is None:
-            mask_shape = self.mask.shape
-            self._transf_matrix = np.array([[1.0 / self.precision, 0, 0, 0],
-                                            [0, -1.0 / self.precision, 0, mask_shape[0]],
-                                            [0, 0, 1, 0], [0, 0, 0, 1]])
-        return self._transf_matrix
+        return np.array([[1.0 / self.resolution, 0, 0, 0],
+                         [0, -1.0 / self.resolution, 0, self.base_mask.shape[0]],
+                         [0, 0, 1, 0], [0, 0, 0, 1]])
 
-    def dilate_mask(self, dist_thresh: float = 2.0) -> None:
+    @cached(cache=LRUCache(maxsize=3))
+    def dilated_mask(self, dilation: float = 2.0) -> np.ndarray:
         """
-        Dilates the mask by a distance threshold.
-        :param dist_thresh: This parameter specifies the threshold on the distance from the semantic prior mask.
-            The semantic prior mask is dilated to include points which are within this distance from itself.
+        Sometimes it is convenient to dilate the drivable surface mask a bit. This method does that for you.
+        :param dilation: <float>. Dilation in meters.
+        :return: <np.ndarray>
         """
-        # Distance to nearest foreground in mask.
-        distance_mask = cv2.distanceTransform((self.foreground - self.mask).astype(np.uint8), cv2.DIST_L2, 5)
-        distance_mask = (distance_mask * self.precision).astype(np.float32)
+        distance_mask = cv2.distanceTransform((self.foreground - self.base_mask).astype(np.uint8), cv2.DIST_L2, 5)
+        distance_mask = (distance_mask * self.resolution).astype(np.float32)
+        return (distance_mask < dilation).astype(np.uint8) * self.foreground
 
-        self._mask = (distance_mask < dist_thresh).astype(np.uint8) * self.foreground
-
-    def export_to_png(self, filename: str='mask.png') -> None:
+    @property
+    @cached(cache=LRUCache(maxsize=1))
+    def base_mask(self) -> np.ndarray:
         """
-        Export mask to png file.
-        :param filename: Path to the png file.
+        Returns the original binary mask stored in map png file.
+        :return: <np.int8: image.height, image.width>. The binary mask.
         """
-        cv2.imwrite(filename=filename, img=self.mask)
+        # Pillow allows us to specify the maximum image size above, whereas this is more difficult in OpenCV.
+        img = Image.open(self.img_file)
 
-    def is_on_mask(self, x, y) -> np.array:
-        """
-        Determine whether the points are on binary mask.
-        :param x: Global x coordinates. Can be a scalar, list or a numpy array of x coordinates.
-        :param y: Global y coordinates. Can be a scalar, list or a numpy array of x coordinates.
-        :return: <np.bool: x.shape>. Whether the points are on the mask.
-        """
+        # Resize map mask to desired resolution.
+        native_resolution = 0.1
+        size_x = int(img.size[0] / self.resolution * native_resolution)
+        size_y = int(img.size[1] / self.resolution * native_resolution)
+        img = img.resize((size_x, size_y), resample=Image.NEAREST)
 
-        if not isinstance(x, np.ndarray):
-            x = np.array(x)
-        if not isinstance(y, np.ndarray):
-            y = np.array(y)
+        # Convert to numpy and binarize.
+        raw_mask = np.array(img)
+        raw_mask[raw_mask < 225] = self.background
+        raw_mask[raw_mask >= 225] = self.foreground
 
-        assert x.shape == y.shape
-
-        if x.ndim == 0:
-            x = np.atleast_1d(x)
-        if y.ndim == 0:
-            y = np.atleast_1d(y)
-
-        assert x.ndim == y.ndim == 1
-
-        px, py = self.get_pixel(x, y)
-
-        on_mask = np.ones(x.size, dtype=np.bool)
-
-        on_mask[px < 0] = False
-        on_mask[px >= self.mask.shape[1]] = False
-        on_mask[py < 0] = False
-        on_mask[py >= self.mask.shape[0]] = False
-
-        on_mask[on_mask] = (self.mask[py[on_mask], px[on_mask]] == self.foreground)
-
-        return on_mask
-
-    def get_pixel(self, x: np.array, y: np.array) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Get the image coordinates given the x-y coordinates of points.
-        :param x: Global x coordinates.
-        :param y: Global y coordinates.
-        :return: (px <np.uint8: x.shape>, py <np.uint8: y.shape>). Pixel coordinates in map.
-        """
-        px, py = (x / self.precision).astype(int), self.mask.shape[0] - (y / self.precision).astype(int)
-
-        return px, py
-
+        return raw_mask

--- a/python-sdk/nuscenes/utils/tests/test_map_mask.py
+++ b/python-sdk/nuscenes/utils/tests/test_map_mask.py
@@ -1,0 +1,122 @@
+import unittest
+import cv2
+import os
+
+import numpy as np
+from nuscenes.utils.map_mask import MapMask
+
+
+class TestLoad(unittest.TestCase):
+
+    fixture = 'testmap.png'
+    foreground = 255
+    native_res = 0.1  # Maps defined on a 0.1 meter resolution grid.
+    small_number = 0.00001  # Just a small numbers to avoid edge effects.
+    half_gt = native_res / 2 + small_number  # Just larger than half a cell.
+    half_lt = native_res / 2 - small_number  # Just smaller than half a cell.
+
+    def setUp(self):
+
+        # Build a test map. 5 x 4 meters. All background except one pixel.
+        mask = np.zeros((50, 40))
+
+        # Native resolution is 0.1
+        # Transformation in y is defined as y_pixel = nrows - y_meters /  resolution
+        # Transformation in x is defined as x_pixel = x_meters /  resolution
+        # The global map location x=2, y=2 becomes row 30, column 20 in image map coords.
+        mask[30, 20] = self.foreground
+        cv2.imwrite(filename=self.fixture, img=mask)
+
+    def tearDown(self):
+        os.remove(self.fixture)
+
+    def test_native_resolution(self):
+
+        # Load mask and assert that the
+        map_mask = MapMask(self.fixture, resolution=0.1)
+
+        # This is where we put the foreground in the fixture, so this should be true by design.
+        self.assertTrue(map_mask.is_on_mask(2, 2))
+
+        # Each pixel is 10 x 10 cm, so if we step less than 5 cm in either direction we are still on foreground.
+        # Note that we add / subtract a "small number" to break numerical ambiguities along the edges.
+        self.assertTrue(map_mask.is_on_mask(2 + self.half_lt, 2))
+        self.assertTrue(map_mask.is_on_mask(2 - self.half_lt, 2))
+        self.assertTrue(map_mask.is_on_mask(2, 2 + self.half_lt))
+        self.assertTrue(map_mask.is_on_mask(2, 2 - self.half_lt))
+
+        # But if we step outside this range, we should get false
+        self.assertFalse(map_mask.is_on_mask(2 + self.half_gt, 2))
+        self.assertFalse(map_mask.is_on_mask(2 + self.half_gt, 2))
+        self.assertFalse(map_mask.is_on_mask(2, 2 + self.half_gt))
+        self.assertFalse(map_mask.is_on_mask(2, 2 + self.half_gt))
+
+    def test_edges(self):
+
+        # Add foreground pixels in the corners for this test.
+        mask = np.ones((50, 40)) * self.foreground
+
+        # Just over-write the fixture
+        cv2.imwrite(filename=self.fixture, img=mask)
+
+        map_mask = MapMask(self.fixture, resolution=0.1)
+
+        # Asssert that corners are indeed drivable as encoded in map.
+        self.assertTrue(map_mask.is_on_mask(0, 0.1))
+        self.assertTrue(map_mask.is_on_mask(0, 5))
+        self.assertTrue(map_mask.is_on_mask(3.9, 0.1))
+        self.assertTrue(map_mask.is_on_mask(3.9, 5))
+
+        # Not go juuuust outside the map. This should no longer be drivable.
+        self.assertFalse(map_mask.is_on_mask(3.9 + self.half_gt, 0.1))
+        self.assertFalse(map_mask.is_on_mask(3.9 + self.half_gt, 5))
+        self.assertFalse(map_mask.is_on_mask(0 - self.half_gt, 0.1))
+        self.assertFalse(map_mask.is_on_mask(0 - self.half_gt, 5))
+
+    def test_dilation(self):
+
+        map_mask = MapMask(self.fixture, resolution=0.1)
+
+        # This is where we put the foreground in the fixture, so this should be true by design.
+        self.assertTrue(map_mask.is_on_mask(2, 2))
+
+        # Go 1 meter to the right. Obviously not on the mask.
+        self.assertFalse(map_mask.is_on_mask(2, 3))
+
+        # But if we dilate by 1 meters, we are on the dilated mask.
+        self.assertTrue(map_mask.is_on_mask(2, 3, dilation=1))  # x direction
+        self.assertTrue(map_mask.is_on_mask(3, 2, dilation=1))  # y direction
+        self.assertTrue(map_mask.is_on_mask(2 + np.sqrt(1/2), 2 + np.sqrt(1/2), dilation=1))  # diagonal
+
+        # If we dilate by 0.9 meter, it is not enough.
+        self.assertFalse(map_mask.is_on_mask(2, 3, dilation=0.9))
+
+    def test_coarse_resolution(self):
+
+        # Due to resize that happens on load we need to inflate the fixture.
+        mask = np.zeros((50, 40))
+        mask[30, 20] = self.foreground
+        mask[31, 20] = self.foreground
+        mask[30, 21] = self.foreground
+        mask[31, 21] = self.foreground
+
+        # Just over-write the fixture
+        cv2.imwrite(filename=self.fixture, img=mask)
+
+        map_mask = MapMask(self.fixture, resolution=0.2)
+
+        # This is where we put the foreground in the fixture, so this should be true by design.
+        self.assertTrue(map_mask.is_on_mask(2, 2))
+
+        # Go two meters to the right. Obviously not on the mask.
+        self.assertFalse(map_mask.is_on_mask(2, 4))
+
+        # But if we dilate by two meters, we are on the dilated mask.
+        self.assertTrue(map_mask.is_on_mask(2, 4, dilation=2))
+
+        # And if we dilate by 1.9 meter, we are off the dilated mask.
+        self.assertFalse(map_mask.is_on_mask(2, 4, dilation=1.9))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python-sdk/tutorial.ipynb
+++ b/python-sdk/tutorial.ipynb
@@ -14,9 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Let's start by initializing the database\n",
@@ -310,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We can also plot all annotations across all sample data for that sample.\n",
@@ -346,9 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We can even render a specific annotation.\n",
@@ -403,9 +397,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nuenv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "nuenv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorial.ipynb
+++ b/python-sdk/tutorial.ipynb
@@ -403,9 +403,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "nuenv",
    "language": "python",
-   "name": "python3"
+   "name": "nuenv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyquaternion==0.9.2
 scikit-learn==0.19.2
 tqdm==4.25.0
 scipy==1.1.0
+cachetools==3.1.0


### PR DESCRIPTION
This cleans up the MAP API.

1) Remove accumulative dilation behavior.
2) Uses caching library
3) Renames `get_pixel` to `to_map_coord`. This now calls `transform_matrix` instead of re-implementing logic.
4) Supports different resolution on init. This helps clean up the Explorer code.

TODO:
* [x] Add tests.
* [ ] Update to load new binary format, use 1 for foreground and 0 for background.
