### PR TITLE
Evaluation Fixes

### DIFF
--- a/python-sdk/nuscenes/eval/eval_utils.py
+++ b/python-sdk/nuscenes/eval/eval_utils.py
@@ -130,7 +130,7 @@ def filter_boxes(sample_boxes: List[Dict], pose_record: Dict, cs_record: Dict, e
     result = []
     ego_dists = []
     for box_sensor, box_global in zip(sample_boxes_sensor, sample_boxes):
-        dist = np.sqrt(np.sum(box_sensor.center ** 2))
+        dist = np.sqrt(np.sum(box_sensor.center[:2] ** 2))
         if dist <= eval_range:
             result.append(box_global)  # Add the sample_box, not the box.
             ego_dists.append(dist)

--- a/python-sdk/nuscenes/eval/nuscenes_eval.py
+++ b/python-sdk/nuscenes/eval/nuscenes_eval.py
@@ -421,10 +421,6 @@ class NuScenesEval:
         else:
             rec = 0 * tp
 
-        # Store original values.
-        metrics['rec'] = rec
-        metrics['prec'] = prec
-
         # IF there are no data points, add a point at (rec, prec) of (0.01, 0) such that the AP equals 0.
         if len(prec) == 0:
             rec = np.array([0.01])
@@ -434,6 +430,20 @@ class NuScenesEval:
         if rec[0] != 0:
             rec = np.append(0.0, rec)
             prec = np.append(prec[0], prec)
+            metrics['trans_err'].insert(0, np.nan)
+            metrics['vel_err'].insert(0, np.nan)
+            metrics['scale_err'].insert(0, np.nan)
+            metrics['orient_err'].insert(0, np.nan)
+            metrics['attr_err'].insert(0, np.nan)
+            metrics['conf'].insert(0, 1)
+
+            # For debugging only.
+            metrics['ego_dist'].insert(0, np.nan)
+            metrics['vel_magn'].insert(0, np.nan)
+
+        # Store modified rec and prec values.
+        metrics['rec'] = rec
+        metrics['prec'] = prec
 
         # Find indices of rec that are close to the interpolated recall thresholds.
         assert all(rec == sorted(rec))  # np.searchsorted requires sorted inputs.
@@ -441,7 +451,7 @@ class NuScenesEval:
         rec_interp = np.linspace(score_range[0], score_range[1], thresh_count)
         threshold_inds = np.searchsorted(rec, rec_interp, side='left').astype(np.float32)
         threshold_inds[threshold_inds == len(rec)] = np.nan  # Mark unachieved recall values as such.
-        assert np.nanmax(threshold_inds) < len(sortind)  # Check that threshold indices are not out of bounds.
+        assert np.nanmax(threshold_inds) < len(rec)  # Check that threshold indices are not out of bounds.
         metrics['threshold_inds'] = threshold_inds
 
         # Interpolation of precisions to the nearest lower recall threshold.

--- a/python-sdk/nuscenes/eval/nuscenes_eval.py
+++ b/python-sdk/nuscenes/eval/nuscenes_eval.py
@@ -444,6 +444,10 @@ class NuScenesEval:
         # Store modified rec and prec values.
         metrics['rec'] = rec
         metrics['prec'] = prec
+        
+        # If the max recall is below the minimum recall range, return the maximum error
+        if max(rec) < min(score_range):
+            return np.nan, dict()
 
         # Find indices of rec that are close to the interpolated recall thresholds.
         assert all(rec == sorted(rec))  # np.searchsorted requires sorted inputs.


### PR DESCRIPTION
This does three changes to the evaluation code:

1. switch distance from xyz to xy as is used elsewhere in evaluation
2. ensure that when an extra recall of zero is added that the other metrics are also updated
3. return the maximum error when the minimum recall is not achieved