### PR TITLE
Changes to calculating distance from ego_vehicle

### DIFF
--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -78,7 +78,7 @@ class EvalBoxes:
         return self.boxes[item]
 
     @property
-    def all(self):
+    def all(self) -> List[EvalBox]:
         ab = []
         for sample_token in self.sample_tokens:
             ab.extend(self[sample_token])

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -115,7 +115,8 @@ class TestEndToEnd(unittest.TestCase):
         metrics = nusc_eval.run()
 
         # Score of 0.22082865720221012 was measured on the branch "release_v0.2" on March 7 2019.
-        self.assertAlmostEqual(metrics['weighted_sum'], 0.22082865720221012)
+        # After changing to measure center distance from the ego-vehicle this changed to 0.2199307290627096
+        self.assertAlmostEqual(metrics['weighted_sum'], 0.2199307290627096)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think we should use the ego vehicle pose when we calculate `EvalBox.ego_dist`. Feels more intuitive than picking the LIDAR sensor (even if, arguably, the LIDAR is closer to the center than the ego vehicle origin itself). This also helped clean up the code a bunch ;) 

