### PR TITLE
Misc Reorg

### DIFF
--- a/python-sdk/nuscenes/__init__.py
+++ b/python-sdk/nuscenes/__init__.py
@@ -1,0 +1,1 @@
+from .nuscenes import NuScenes, NuScenesExplorer

--- a/python-sdk/nuscenes/eval/detection/__init__.py
+++ b/python-sdk/nuscenes/eval/detection/__init__.py
@@ -1,0 +1,1 @@
+from .main import NuScenesEval

--- a/python-sdk/nuscenes/eval/detection/main.py
+++ b/python-sdk/nuscenes/eval/detection/main.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 import numpy as np
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 from nuscenes.eval.detection.utils import dist_fcn_map
 from nuscenes.eval.detection.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
 from nuscenes.eval.detection.data_classes import DetectionConfig

--- a/python-sdk/nuscenes/eval/detection/render.py
+++ b/python-sdk/nuscenes/eval/detection/render.py
@@ -3,7 +3,7 @@ from typing import Dict
 import numpy as np
 from matplotlib import pyplot as plt
 from nuscenes.eval.detection.utils import boxes_to_sensor
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 from nuscenes.utils.data_classes import LidarPointCloud
 from nuscenes.utils.geometry_utils import view_points
 

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -12,10 +12,10 @@ from typing import Dict
 from tqdm import tqdm
 import numpy as np
 
-from nuscenes.eval.detection.main import NuScenesEval
+from nuscenes.eval.detection import NuScenesEval
 from nuscenes.eval.detection.utils import category_to_detection_name, detection_name_to_rel_attributes
 from nuscenes.eval.detection.data_classes import DetectionConfig
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 from nuscenes.utils.splits import create_splits_scenes
 
 

--- a/python-sdk/nuscenes/eval/detection/tests/test_utils.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_utils.py
@@ -7,8 +7,8 @@ import unittest
 import numpy as np
 from pyquaternion import Quaternion
 
-from nuscenes.eval.detection.utils import scale_iou, quaternion_yaw, yaw_diff
 from nuscenes.eval.detection.data_classes import EvalBox
+from nuscenes.eval.detection.utils import scale_iou, yaw_diff
 
 
 class TestEval(unittest.TestCase):
@@ -53,48 +53,6 @@ class TestEval(unittest.TestCase):
         sa = EvalBox(size=[4, 4, 4])
         sr = EvalBox(size=[4, -5, 4])
         self.assertRaises(AssertionError, scale_iou, sa, sr)
-
-    def test_quaternion_yaw(self):
-        """Test valid and invalid inputs for quaternion_yaw()."""
-
-        # Misc yaws.
-        for yaw_in in np.linspace(-10, 10, 100):
-            q = Quaternion(axis=(0, 0, 1), angle=yaw_in)
-            yaw_true = yaw_in % (2 * np.pi)
-            if yaw_true > np.pi:
-                yaw_true -= 2 * np.pi
-            yaw_test = quaternion_yaw(q)
-            self.assertAlmostEqual(yaw_true, yaw_test)
-
-        # Non unit axis vector.
-        yaw_in = np.pi/4
-        q = Quaternion(axis=(0, 0, 0.5), angle=yaw_in)
-        yaw_test = quaternion_yaw(q)
-        self.assertAlmostEqual(yaw_in, yaw_test)
-
-        # Inverted axis vector.
-        yaw_in = np.pi/4
-        q = Quaternion(axis=(0, 0, -1), angle=yaw_in)
-        yaw_test = -quaternion_yaw(q)
-        self.assertAlmostEqual(yaw_in, yaw_test)
-
-        # Rotate around another axis.
-        yaw_in = np.pi/4
-        q = Quaternion(axis=(0, 1, 0), angle=yaw_in)
-        yaw_test = quaternion_yaw(q)
-        self.assertAlmostEqual(0, yaw_test)
-
-        # Rotate around two axes jointly.
-        yaw_in = np.pi/2
-        q = Quaternion(axis=(0, 1, 1), angle=yaw_in)
-        yaw_test = quaternion_yaw(q)
-        self.assertAlmostEqual(yaw_in, yaw_test)
-
-        # Rotate around two axes separately.
-        yaw_in = np.pi/2
-        q = Quaternion(axis=(0, 0, 1), angle=yaw_in) * Quaternion(axis=(0, 1, 0), angle=0.5821)
-        yaw_test = quaternion_yaw(q)
-        self.assertAlmostEqual(yaw_in, yaw_test)
 
     def test_yaw_diff(self):
         """Test valid and invalid inputs for yaw_diff()."""

--- a/python-sdk/nuscenes/eval/detection/utils.py
+++ b/python-sdk/nuscenes/eval/detection/utils.py
@@ -2,13 +2,13 @@
 # Code written by Holger Caesar, 2018.
 # Licensed under the Creative Commons [see licence.txt]
 
-from typing import List, Dict, Optional
-
 import numpy as np
 from pyquaternion import Quaternion
+from typing import List, Dict, Optional
 
-from nuscenes.utils.data_classes import Box
 from nuscenes.eval.detection.data_classes import EvalBox
+from nuscenes.utils.data_classes import Box
+from nuscenes.utils.geometry_utils import quaternion_yaw
 
 
 def category_to_detection_name(category_name: str) -> Optional[str]:
@@ -147,24 +147,6 @@ def scale_iou(sample_annotation: EvalBox, sample_result: EvalBox) -> float:
     iou = intersection / union
 
     return iou
-
-
-def quaternion_yaw(q: Quaternion) -> float:
-    """
-    Calculate the yaw angle from a quaternion.
-    Note that this only works for a quaternion that represents a box in lidar or global coordinate frame.
-    It does not work for a box in the camera frame.
-    :param q: Quaternion of interest.
-    :return: Yaw angle in radians.
-    """
-
-    # Project into xy plane.
-    v = np.dot(q.rotation_matrix, np.array([1, 0, 0]))
-
-    # Measure yaw using arctan.
-    yaw = np.arctan2(v[1], v[0])
-
-    return yaw
 
 
 def boxes_to_sensor(boxes: List[EvalBox], pose_record: Dict, cs_record: Dict):

--- a/python-sdk/nuscenes/eval/detection/utils.py
+++ b/python-sdk/nuscenes/eval/detection/utils.py
@@ -8,7 +8,6 @@ from typing import List, Dict, Optional
 
 from nuscenes.eval.detection.data_classes import EvalBox
 from nuscenes.utils.data_classes import Box
-from nuscenes.utils.geometry_utils import quaternion_yaw
 
 
 def category_to_detection_name(category_name: str) -> Optional[str]:
@@ -147,6 +146,24 @@ def scale_iou(sample_annotation: EvalBox, sample_result: EvalBox) -> float:
     iou = intersection / union
 
     return iou
+
+
+def quaternion_yaw(q: Quaternion) -> float:
+    """
+    Calculate the yaw angle from a quaternion.
+    Note that this only works for a quaternion that represents a box in lidar or global coordinate frame.
+    It does not work for a box in the camera frame.
+    :param q: Quaternion of interest.
+    :return: Yaw angle in radians.
+    """
+
+    # Project into xy plane.
+    v = np.dot(q.rotation_matrix, np.array([1, 0, 0]))
+
+    # Measure yaw using arctan.
+    yaw = np.arctan2(v[1], v[0])
+
+    return yaw
 
 
 def boxes_to_sensor(boxes: List[EvalBox], pose_record: Dict, cs_record: Dict):

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -5,25 +5,24 @@
 from __future__ import annotations
 
 import json
-import time
-import sys
 import os.path as osp
+import sys
+import time
 from datetime import datetime
-from typing import Tuple, List
 
 import cv2
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import sklearn.metrics
 from PIL import Image
 from matplotlib.axes import Axes
 from pyquaternion import Quaternion
-import sklearn.metrics
 from tqdm import tqdm
+from typing import Tuple, List
 
-from nuscenes.utils.map_mask import MapMask
 from nuscenes.utils.data_classes import LidarPointCloud, RadarPointCloud, Box
-from nuscenes.utils.geometry_utils import view_points, box_in_image, quaternion_slerp, BoxVisibility
-
+from nuscenes.utils.geometry_utils import view_points, box_in_image, BoxVisibility
+from nuscenes.utils.map_mask import MapMask
 
 PYTHON_VERSION = sys.version_info[0]
 
@@ -307,10 +306,10 @@ class NuScenes:
                     center = [np.interp(t, [t0, t1], [c0, c1]) for c0, c1 in zip(prev_ann_rec['translation'],
                                                                                  curr_ann_rec['translation'])]
 
-                    # Interpolate orientation. (There is a bug in pyquaternion.slerp() so use external method.)
-                    rotation = Quaternion(quaternion_slerp(np.array(prev_ann_rec['rotation']),
-                                                           np.array(curr_ann_rec['rotation']),
-                                                           (t - t0) / (t1 - t0)))
+                    # Interpolate orientation.
+                    rotation = Quaternion.slerp(q0=Quaternion(prev_ann_rec['rotation']),
+                                                q1=Quaternion(curr_ann_rec['rotation']),
+                                                amount=(t - t0) / (t1 - t0))
 
                     box = Box(center, curr_ann_rec['size'], rotation, name=curr_ann_rec['category_name'])
                 else:

--- a/python-sdk/nuscenes/scripts/assert_download.py
+++ b/python-sdk/nuscenes/scripts/assert_download.py
@@ -6,7 +6,7 @@ import argparse
 import os
 from tqdm import tqdm
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 
 def verify_setup(nusc: NuScenes):

--- a/python-sdk/nuscenes/scripts/export_egoposes_on_map.py
+++ b/python-sdk/nuscenes/scripts/export_egoposes_on_map.py
@@ -10,7 +10,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 # Load NuScenes class
 nusc = NuScenes()

--- a/python-sdk/nuscenes/scripts/export_pointclouds_as_obj.py
+++ b/python-sdk/nuscenes/scripts/export_pointclouds_as_obj.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 from nuscenes.utils.data_classes import LidarPointCloud
 from nuscenes.utils.geometry_utils import view_points
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 
 def export_scene_pointcloud(nusc: NuScenes,

--- a/python-sdk/nuscenes/scripts/export_scene_videos.py
+++ b/python-sdk/nuscenes/scripts/export_scene_videos.py
@@ -7,7 +7,7 @@ Exports a video of each scene (with annotations) to disk.
 """
 import os
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 # Load NuScenes class
 nusc = NuScenes()

--- a/python-sdk/nuscenes/tests/test_nuscenes.py
+++ b/python-sdk/nuscenes/tests/test_nuscenes.py
@@ -5,7 +5,7 @@
 import unittest
 import os
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 
 class TestNuScenes(unittest.TestCase):

--- a/python-sdk/nuscenes/utils/geometry_utils.py
+++ b/python-sdk/nuscenes/utils/geometry_utils.py
@@ -108,21 +108,3 @@ def transform_matrix(translation: np.ndarray = np.array([0, 0, 0]),
         tm[:3, 3] = np.transpose(np.array(translation))
 
     return tm
-
-
-def quaternion_yaw(q: Quaternion) -> float:
-    """
-    Calculate the yaw angle from a quaternion.
-    Note that this only works for a quaternion that represents a box in lidar or global coordinate frame.
-    It does not work for a box in the camera frame.
-    :param q: Quaternion of interest.
-    :return: Yaw angle in radians.
-    """
-
-    # Project into xy plane.
-    v = np.dot(q.rotation_matrix, np.array([1, 0, 0]))
-
-    # Measure yaw using arctan.
-    yaw = np.arctan2(v[1], v[0])
-
-    return yaw

--- a/python-sdk/nuscenes/utils/splits.py
+++ b/python-sdk/nuscenes/utils/splits.py
@@ -5,7 +5,7 @@
 from typing import Dict, List
 import argparse
 
-from nuscenes.nuscenes import NuScenes
+from nuscenes import NuScenes
 
 train = \
     ['scene-0001', 'scene-0002', 'scene-0004', 'scene-0005', 'scene-0006', 'scene-0007', 'scene-0008', 'scene-0009',

--- a/python-sdk/nuscenes/utils/tests/test_geometry_utils.py
+++ b/python-sdk/nuscenes/utils/tests/test_geometry_utils.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from pyquaternion import Quaternion
 
-from nuscenes.utils.geometry_utils import quaternion_yaw
+from nuscenes.eval.detection.utils import quaternion_yaw
 
 
 class TestGeometryUtils(unittest.TestCase):

--- a/python-sdk/nuscenes/utils/tests/test_geometry_utils.py
+++ b/python-sdk/nuscenes/utils/tests/test_geometry_utils.py
@@ -1,0 +1,59 @@
+# nuScenes dev-kit.
+# Code written by Holger Caesar, 2018.
+# Licensed under the Creative Commons [see licence.txt]
+
+import unittest
+
+import numpy as np
+from pyquaternion import Quaternion
+
+from nuscenes.utils.geometry_utils import quaternion_yaw
+
+
+class TestGeometryUtils(unittest.TestCase):
+
+    def test_quaternion_yaw(self):
+        """Test valid and invalid inputs for quaternion_yaw()."""
+
+        # Misc yaws.
+        for yaw_in in np.linspace(-10, 10, 100):
+            q = Quaternion(axis=(0, 0, 1), angle=yaw_in)
+            yaw_true = yaw_in % (2 * np.pi)
+            if yaw_true > np.pi:
+                yaw_true -= 2 * np.pi
+            yaw_test = quaternion_yaw(q)
+            self.assertAlmostEqual(yaw_true, yaw_test)
+
+        # Non unit axis vector.
+        yaw_in = np.pi/4
+        q = Quaternion(axis=(0, 0, 0.5), angle=yaw_in)
+        yaw_test = quaternion_yaw(q)
+        self.assertAlmostEqual(yaw_in, yaw_test)
+
+        # Inverted axis vector.
+        yaw_in = np.pi/4
+        q = Quaternion(axis=(0, 0, -1), angle=yaw_in)
+        yaw_test = -quaternion_yaw(q)
+        self.assertAlmostEqual(yaw_in, yaw_test)
+
+        # Rotate around another axis.
+        yaw_in = np.pi/4
+        q = Quaternion(axis=(0, 1, 0), angle=yaw_in)
+        yaw_test = quaternion_yaw(q)
+        self.assertAlmostEqual(0, yaw_test)
+
+        # Rotate around two axes jointly.
+        yaw_in = np.pi/2
+        q = Quaternion(axis=(0, 1, 1), angle=yaw_in)
+        yaw_test = quaternion_yaw(q)
+        self.assertAlmostEqual(yaw_in, yaw_test)
+
+        # Rotate around two axes separately.
+        yaw_in = np.pi/2
+        q = Quaternion(axis=(0, 0, 1), angle=yaw_in) * Quaternion(axis=(0, 1, 0), angle=0.5821)
+        yaw_test = quaternion_yaw(q)
+        self.assertAlmostEqual(yaw_in, yaw_test)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==2.2.3
 numpy==1.14.5
 opencv-python==3.4.2.17
 Pillow==5.2.0
-pyquaternion==0.9.2
+pyquaternion==0.9.5
 scikit-learn==0.19.2
 tqdm==4.25.0
 scipy==1.1.0


### PR DESCRIPTION
This PR does three things:

1. ~~Move quaternion_yaw out of eval utils to general utils~~
2. Eliminate quaternion_slerp now that pyquaternion is fixed
3. Add some shortcuts to common classes

If (3) is not desired, we can revert commit 75c42f9