### PR TITLE
Orientation handling and asserts

### DIFF
--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -205,11 +205,11 @@ def calc_ap(md: MetricData, min_recall: float, min_precision: float) -> float:
 
 
 def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:
-    """ Calculates true positive metrics """
+    """ Calculates true positive errors. """
 
     first_ind = round(100 * min_recall)
     last_ind = np.nonzero(md.confidence)[0][-1]  # First instance of confidence = 0 is index of max achived recall.
     if last_ind < first_ind:
-        return 1  # Assign 1 here. If this happends for all classes, the score for that TP metric will be 0.
+        return 1  # Assign 1 here. If this happens for all classes, the score for that TP metric will be 0.
     else:
         return float(np.mean(getattr(md, metric_name)[first_ind: last_ind]))

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -208,7 +208,7 @@ def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:
     """ Calculates true positive errors. """
 
     first_ind = round(100 * min_recall)
-    last_ind = np.nonzero(md.confidence)[0][-1]  # First instance of confidence = 0 is index of max achived recall.
+    last_ind = np.nonzero(md.confidence)[0][-1]  # First instance of confidence = 0 is index of max achieved recall.
     if last_ind < first_ind:
         return 1  # Assign 1 here. If this happens for all classes, the score for that TP metric will be 0.
     else:

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -205,4 +205,7 @@ def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:
 
     first_ind = round(100 * min_recall)
     last_ind = np.nonzero(md.confidence)[0][-1]  # First instance of confidence = 0 is index of max achived recall.
-    return float(np.mean(getattr(md, metric_name)[first_ind: last_ind]))
+    if last_ind < first_ind:
+        return 1  # Assign 1 here. If this happends for all classes, the score for that TP metric will be 0.
+    else:
+        return float(np.mean(getattr(md, metric_name)[first_ind: last_ind]))

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -98,7 +98,11 @@ def accumulate(gt_boxes: EvalBoxes,
             match_data['trans_err'].append(center_distance(gt_box_match, pred_box))
             match_data['vel_err'].append(velocity_l2(gt_box_match, pred_box))
             match_data['scale_err'].append(1 - scale_iou(gt_box_match, pred_box))
-            match_data['orient_err'].append(yaw_diff(gt_box_match, pred_box))
+
+            # Barrier orientation is only determined up to 180 degree. (For cones orientation is discarded later)
+            period = np.pi if class_name == 'barrier' else 2 * np.pi
+            match_data['orient_err'].append(yaw_diff(gt_box_match, pred_box, period=period))
+
             match_data['attr_err'].append(1 - attr_acc(gt_box_match, pred_box))
             match_data['conf'].append(pred_box.detection_score)
 

--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -314,14 +314,14 @@ class DetectionMetrics:
         for metric_name in TP_METRICS:
             errors = []
             for detection_name in self.cfg.class_names:
-                if detection_name in ['traffic_cone'] and metric_name in ['attr_err', 'orientation', 'velocity']:
+                if detection_name in ['traffic_cone'] and metric_name in ['attr_err', 'vel_err', 'orient_err']:
                     # We don't include this in mean since:
                     # - We dont have attributes for cones.
-                    # - Orientation of a cone is ill-defined.
                     # - Cones are stationary.
+                    # - Orientation of a cone is ill-defined.
                     continue
 
-                if detection_name in ['barrier'] and metric_name in ['attr_err', 'velocity']:
+                if detection_name in ['barrier'] and metric_name in ['attr_err', 'vel_err']:
                     # We don't include this in mean since:
                     # - We dont have attributes for cones.
                     # - Barriers are stationary.

--- a/python-sdk/nuscenes/eval/detection/main.py
+++ b/python-sdk/nuscenes/eval/detection/main.py
@@ -92,7 +92,7 @@ class NuScenesEval:
         for class_name in self.cfg.class_names:
             for dist_th in self.cfg.dist_ths:
                 md = accumulate(self.gt_boxes, self.pred_boxes, class_name, self.cfg.dist_fcn, dist_th)
-                metric_data_list.add(class_name, dist_th, md)
+                metric_data_list.set(class_name, dist_th, md)
 
         # -----------------------------------
         # Step 2: Calculate metrics from the data

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -118,7 +118,7 @@ class TestAlgo(unittest.TestCase):
                 tp = calc_tp(mdl[(class_name, self.cfg.dist_th_tp)], self.cfg.min_recall, metric_name)
                 metrics.add_label_tp(class_name, metric_name, tp)
 
-        self.assertEqual(0.135073927045973, metrics.weighted_sum)
+        self.assertEqual(0.101181797324938, metrics.weighted_sum)
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -106,7 +106,7 @@ class TestAlgo(unittest.TestCase):
         for class_name in self.cfg.class_names:
             gt, pred = self._mock_results(30, 3, 25, class_name)
             for dist_th in self.cfg.dist_ths:
-                mdl.add(class_name, dist_th, accumulate(gt, pred, class_name, 'center_distance', 2))
+                mdl.set(class_name, dist_th, accumulate(gt, pred, class_name, 'center_distance', 2))
 
         metrics = DetectionMetrics(self.cfg)
         for class_name in self.cfg.class_names:

--- a/python-sdk/nuscenes/eval/detection/tests/test_data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_data_classes.py
@@ -5,25 +5,48 @@
 import json
 import unittest
 
-from nuscenes.eval.detection.data_classes import MetricData, MetricDataList
+from nuscenes.eval.detection.data_classes import MetricData, EvalBox, EvalBoxes, MetricDataList
 
 
 class TestMetricData(unittest.TestCase):
 
     def test_serialization(self):
-        md1 = MetricData.random_md()
-        md2 = MetricData.deserialize(json.loads(json.dumps(md1.serialize())))
-        self.assertEqual(md1, md2)
+        """ test that instance serialization protocol works with json encodeding """
+        md = MetricData.random_md()
+        recovered = MetricData.deserialize(json.loads(json.dumps(md.serialize())))
+        self.assertEqual(md, recovered)
 
 
 class TestMetricDataList(unittest.TestCase):
 
     def test_serialization(self):
-        mdl1 = MetricDataList()
+        """ test that instance serialization protocol works with json encodeding """
+        mdl = MetricDataList()
         for i in range(10):
-            mdl1.add('name', 0.1, MetricData.random_md())
-        mdl2 = MetricDataList.deserialize(json.loads(json.dumps(mdl1.serialize())))
-        self.assertEqual(mdl1, mdl2)
+            mdl.set('name', 0.1, MetricData.random_md())
+        recovered = MetricDataList.deserialize(json.loads(json.dumps(mdl.serialize())))
+        self.assertEqual(mdl, recovered)
+
+
+class TestEvalBox(unittest.TestCase):
+
+    def test_serialization(self):
+        """ test that instance serialization protocol works with json encodeding """
+        box = EvalBox()
+        recovered = EvalBox.deserialize(json.loads(json.dumps(box.serialize())))
+        self.assertEqual(box, recovered)
+
+
+class TestEvalBoxes(unittest.TestCase):
+
+    def test_serialization(self):
+        """ test that instance serialization protocol works with json encodeding """
+        boxes = EvalBoxes()
+        for i in range(10):
+            boxes.add_boxes(str(i), [EvalBox(), EvalBox(), EvalBox()])
+
+        recovered = EvalBoxes.deserialize(json.loads(json.dumps(boxes.serialize())))
+        self.assertEqual(boxes, recovered)
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_utils.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_utils.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from pyquaternion import Quaternion
 
-from nuscenes.eval.detection.utils import scale_iou, quaternion_yaw, yaw_diff
+from nuscenes.eval.detection.utils import scale_iou, quaternion_yaw, yaw_diff, angle_diff
 from nuscenes.eval.detection.data_classes import EvalBox
 
 
@@ -128,6 +128,46 @@ class TestEval(unittest.TestCase):
         sr = EvalBox(rotation=Quaternion(axis=(0, 0, 1), angle=0.9 * np.pi).elements)
         diff = yaw_diff(sa, sr)
         self.assertAlmostEqual(diff, 0.2 * np.pi)
+
+    def test_angle_diff(self):
+
+        def rad(x):
+            return x/180*np.pi
+
+        a = 90.0
+        b = 0.0
+        period = 360
+        self.assertAlmostEqual(rad(90), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 90.0
+        b = 0.0
+        period = 180
+        self.assertAlmostEqual(rad(90), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 90.0
+        b = 0.0
+        period = 90
+        self.assertAlmostEqual(rad(0), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 0.0
+        b = 90.0
+        period = 90
+        self.assertAlmostEqual(rad(0), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 0.0
+        b = 180.0
+        period = 180
+        self.assertAlmostEqual(rad(0), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 0.0
+        b = 180.0
+        period = 360
+        self.assertAlmostEqual(rad(180), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+        a = 0.0
+        b = 180.0 + 360*200
+        period = 360
+        self.assertAlmostEqual(rad(180), abs(angle_diff(rad(a), rad(b), rad(period))))
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/utils.py
+++ b/python-sdk/nuscenes/eval/detection/utils.py
@@ -86,21 +86,35 @@ def velocity_l2(gt_box: EvalBox, pred_box: EvalBox) -> float:
         return np.linalg.norm(np.array(pred_box.velocity[:2]) - np.array(gt_box.velocity[:2]))
 
 
-def yaw_diff(sample_annotation: EvalBox, sample_result: EvalBox) -> float:
+def yaw_diff(gt_box: EvalBox, eval_box: EvalBox, period: float = 2*np.pi) -> float:
     """
     Returns the yaw angle difference between the orientation of two boxes.
-    :param sample_annotation: GT annotation sample.
-    :param sample_result: Predicted sample.
+    :param gt_box: Ground truth box.
+    :param eval_box: Predicted box.
+    :param period: Periodicity in radians for assessing angle difference.
     :return: Yaw angle difference in radians in [0, pi].
     """
-    yaw_annotation = quaternion_yaw(Quaternion(sample_annotation.rotation))
-    yaw_result = quaternion_yaw(Quaternion(sample_result.rotation))
+    yaw_gt = quaternion_yaw(Quaternion(gt_box.rotation))
+    yaw_est = quaternion_yaw(Quaternion(eval_box.rotation))
 
-    # Compute smallest angle between two yaw values.
-    angle_diff = abs(yaw_annotation - yaw_result)
-    if angle_diff > np.pi:
-        angle_diff = 2 * np.pi - angle_diff  # Shift (pi, 2*pi] to (0, pi].
-    return angle_diff
+    return abs(angle_diff(yaw_gt, yaw_est, period))
+
+
+def angle_diff(x: float, y: float, period: float):
+    """
+    Get the smallest angle difference between 2 angles: the angle from y to x.
+    :param x: To angle.
+    :param y: From angle.
+    :param period: Periodicity in radians for assessing angle difference.
+    :return: <float>. Signed smallest between-angle difference in range (-pi, pi).
+    """
+
+    # calculate angle difference, modulo to [0, 2*pi]
+    diff = (x - y + period / 2) % period - period / 2
+    if diff > np.pi:
+        diff = diff - (2 * np.pi)  # shift (pi, 2*pi] to (-pi, 0]
+
+    return diff
 
 
 def attr_acc(gt_box: EvalBox, pred_box: EvalBox) -> float:


### PR DESCRIPTION
This PR discards orientation errors for cones. It also measures orientation errors for barriers on a 180 degree period. It further fixed a bug in how we calculate the TP scores. The TP error is now the average across classes. This is in native interpretable units and is what will go on the leaderboard. The score is then simply `max(0, 1-mean_class_tp_err)`.