### PR TITLE
Integrate mini_split into continuous integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,12 +49,7 @@ pipeline {
           // an activated Conda environment inside of the container.
           sh """#!/bin/bash
             set -eux
-            echo 'Building docker image...'
-            docker rm -f $TEST_CONTAINER_NAME || echo "Container does not exist"
-            docker build -t $TEST_IMAGE .
-            docker run --name $TEST_CONTAINER_NAME \
-	      $TEST_IMAGE \
-              bash -c "source activate nuenv && cd python-sdk && python -m unittest"
+            bash test_mini_split.sh
           """
         } // container
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,6 @@ pipeline {
   agent none
 
   environment {
-    TEST_IMAGE = "registry-local.nutonomy.team:5000/nuscenes-test:kube${UUID.nameUUIDFromBytes(new String(env.BUILD_TAG).getBytes())}"
-    TEST_CONTAINER_NAME = "nuscenes-test_container"
     PROD_IMAGE = "nuscenes:production"
   }
 
@@ -52,15 +50,6 @@ pipeline {
             bash test_mini_split.sh
           """
         } // container
-
-        container('docker') {
-        // Remove container if it is already running. We make this a
-        // separate step because this should happen regardless of the
-        // outcome of the previous build and test step.
-          sh """#!/bin/bash
-            docker rm -f $TEST_CONTAINER_NAME || echo "Container does not exist"
-          """
-        }
       }
     } // stage('Build and test')
     stage('Deploy') {

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -133,6 +133,7 @@ class TestEndToEnd(unittest.TestCase):
         # After changing to measure center distance from the ego-vehicle this changed to 0.2199307290627096
         # Changed to 1.0-mini. Cleaned up build script. So new basline at 0.24954451673961747
         self.assertAlmostEqual(metrics['weighted_sum'], 0.24954451673961747)
+        print("Passed unit test test_delta")
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -133,7 +133,6 @@ class TestEndToEnd(unittest.TestCase):
         # After changing to measure center distance from the ego-vehicle this changed to 0.2199307290627096
         # Changed to 1.0-mini. Cleaned up build script. So new basline at 0.24954451673961747
         self.assertAlmostEqual(metrics['weighted_sum'], 0.24954451673961747)
-        print("Passed unit test test_delta")
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -87,7 +87,6 @@ class TestEndToEnd(unittest.TestCase):
             mock_results[sample['token']] = sample_res
         return mock_results
 
-    @unittest.skip
     def test_delta(self):
         """
         This tests runs the evaluation for an arbitrary random set of predictions.

--- a/python-sdk/nuscenes/tests/test_nuscenes.py
+++ b/python-sdk/nuscenes/tests/test_nuscenes.py
@@ -10,7 +10,6 @@ from nuscenes import NuScenes
 
 class TestNuScenes(unittest.TestCase):
 
-    @unittest.skip
     def test_load(self):
         """
         Loads up NuScenes.

--- a/python-sdk/nuscenes/tests/test_nuscenes.py
+++ b/python-sdk/nuscenes/tests/test_nuscenes.py
@@ -21,7 +21,6 @@ class TestNuScenes(unittest.TestCase):
 
         # Trivial assert statement
         self.assertEqual(nusc.table_root, os.path.join(os.environ['NUSCENES'], 'v1.0-mini'))
-        print("Passed unit test test_load")
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/tests/test_nuscenes.py
+++ b/python-sdk/nuscenes/tests/test_nuscenes.py
@@ -21,6 +21,7 @@ class TestNuScenes(unittest.TestCase):
 
         # Trivial assert statement
         self.assertEqual(nusc.table_root, os.path.join(os.environ['NUSCENES'], 'v1.0-mini'))
+        print("Passed unit test test_load")
 
 
 if __name__ == '__main__':

--- a/test_mini_split.sh
+++ b/test_mini_split.sh
@@ -21,7 +21,6 @@ echo "Pulling image containing mini split data from registry"
 docker pull ${data_image} || { echo "error during docker pull;" exit 1; }
 
 echo "Creating Docker volume from container"
-# Create volume from container
 docker run -d --name=${data_container} -v ${data_volume}:/data:ro ${data_image} || { echo "container already running";}
 
 echo "Building image containing nuscenes-devkit"

--- a/test_mini_split.sh
+++ b/test_mini_split.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+data_image=registry-local.nutonomy.team:5000/nuscenes/mini_split_data
+data_container=mini_split_data
+data_volume=mini_split_volume
+
+function cleanup(){
+    echo "Cleaning up docker containers and volumes if they already exist"
+    docker container stop ${data_container} || { echo "container does not exist"; }
+    docker container rm ${data_container} || { echo "container does not exist"; }
+    
+    docker rm -f test_container || { echo "test container does not exist"; }
+    docker volume rm ${data_volume} || { echo "volume does not already exist"; }
+}
+
+cleanup
+
+echo "Pulling image containing mini split data from registry"
+docker pull ${data_image} || { echo "error during docker pull;" exit 1; }
+
+echo "Creating Docker volume from container"
+# Create volume from container
+docker run -d --name=${data_container} -v ${data_volume}:/data:ro ${data_image} || { echo "container already running";}
+
+echo "Building image containing nuscenes-devkit"
+docker build -t test_mini_split . || { echo "Failed to build main Docker image"; exit 1; }
+
+docker run --name=test_container -v ${data_volume}:/data \
+    -e NUSCENES=/data/nuscenes-v1.0 test_mini_split \
+    /bin/bash -c "source activate nuenv && cd python-sdk && python -m unittest"
+
+cleanup

--- a/test_mini_split.sh
+++ b/test_mini_split.sh
@@ -4,7 +4,7 @@ data_image=registry-local.nutonomy.team:5000/nuscenes/mini_split_data
 data_container=mini_split_data
 data_volume=mini_split_volume
 
-function cleanup(){
+function clean_up(){
     echo "Cleaning up docker containers and volumes if they already exist"
     docker container stop ${data_container} || { echo "container does not exist"; }
     docker container rm ${data_container} || { echo "container does not exist"; }
@@ -13,7 +13,9 @@ function cleanup(){
     docker volume rm ${data_volume} || { echo "volume does not already exist"; }
 }
 
-cleanup
+trap clean_up EXIT
+
+clean_up
 
 echo "Pulling image containing mini split data from registry"
 docker pull ${data_image} || { echo "error during docker pull;" exit 1; }
@@ -29,4 +31,4 @@ docker run --name=test_container -v ${data_volume}:/data \
     -e NUSCENES=/data/nuscenes-v1.0 test_mini_split \
     /bin/bash -c "source activate nuenv && cd python-sdk && python -m unittest"
 
-cleanup
+clean_up


### PR DESCRIPTION
In this PR, we enable unit tests in which instances of `NuScenes` with version argument `v1.0-mini` are created.  A separate Docker image containing the data dependencies corresponding to `nuscenes/v1.0-mini` has been pushed to registry https://registry-local.nutonomy.team:5000/nuscenes/mini_split_data. 

Inside of the Jenkins pipeline, the aforementioned Docker image is pulled and then a container containing the `mini_split` data is created.  This container is used to create a Docker volume which can then be mounted into the container containing the `nuscenes-devkit` test code. 

Snippet from Jenkins pipeline corresponding to reading from `mini_split`  : 
`
Successfully tagged test_mini_split:latest


  0%|          | 0/162 [00:00<?, ?it/s]
 25%|██▍       | 40/162 [00:00<00:00, 397.89it/s]
 81%|████████  | 131/162 [00:00<00:00, 648.64it/s]
100%|██████████| 162/162 [00:00<00:00, 624.47it/s]


  0%|          | 0/162 [00:00<?, ?it/s]
 95%|█████████▌| 154/162 [00:00<00:00, 1538.90it/s]
100%|██████████| 162/162 [00:00<00:00, 1559.05it/s]

.........

----------------------------------------------------------------------

Ran 9 tests in 4.104s



OK

Passed unit test test_delta

Passed unit test test_load
`