### PR TITLE
Simple Unittests for AP calculation

### DIFF
--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -173,10 +173,10 @@ def calc_ap(md: MetricData, min_recall: float, min_precision: float) -> float:
     assert 0 <= min_recall <= 1
 
     prec = md.precision
-    prec = prec[round(100 * min_recall):]  # Clip low recalls.
+    prec = prec[round(100 * min_recall) + 1:]  # Clip low recalls.
     prec -= min_precision  # Clip low precision
     prec[prec < 0] = 0
-    return float(np.mean(prec)) / (1.0 - min_precision)
+    return np.mean(prec) / (1.0 - min_precision)
 
 
 def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -176,7 +176,7 @@ def calc_ap(md: MetricData, min_recall: float, min_precision: float) -> float:
     prec = prec[round(100 * min_recall) + 1:]  # Clip low recalls.
     prec -= min_precision  # Clip low precision
     prec[prec < 0] = 0
-    return np.mean(prec) / (1.0 - min_precision)
+    return float(np.mean(prec)) / (1.0 - min_precision)
 
 
 def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -30,7 +30,7 @@ def accumulate(gt_boxes: EvalBoxes,
     dist_fcn = dist_fcn_map[dist_fcn_name]
 
     # ---------------------------------------------
-    # Organize input and inititialize accumulators
+    # Organize input and initialize accumulators
     # ---------------------------------------------
 
     # Count the positives.

--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -369,10 +369,11 @@ class DetectionMetrics:
     @property
     def tp_scores(self) -> Dict[str, float]:
         scores = {}
+        tp_errors = self.tp_errors
         for metric_name in TP_METRICS:
 
             # We convert the true positive errors to "scores" by 1-error
-            score = 1.0 - self.tp_errors[metric_name]
+            score = 1.0 - tp_errors[metric_name]
 
             # Some of the true positive errors are unbounded, so we bound the scores to min 0.
             score = max(0.0, score)

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -113,7 +113,8 @@ class TestMain(unittest.TestCase):
         # 2. Score = 0.2199307290627096. Changed to measure center distance from the ego-vehicle.
         # 3. Score = 0.24954451673961747. Changed to 1.0-mini and cleaned up build script.
         # 4. Score = 0.20478832626986893. Updated treatment of cones, barriers, and other algo tunings.
-        self.assertAlmostEqual(metrics.weighted_sum, 0.20478832626986893)
+        # 5. Score = 0.2043569666105005. AP calculation area is changed from >=min_recall to >min_recall.
+        self.assertAlmostEqual(metrics.weighted_sum, 0.2043569666105005)
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_utils.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_utils.py
@@ -10,7 +10,7 @@ from pyquaternion import Quaternion
 
 from nuscenes.eval.detection.data_classes import EvalBox
 from nuscenes.eval.detection.utils import attr_acc, scale_iou, yaw_diff, angle_diff, center_distance, velocity_l2,\
-    cummean, boxes_to_sensor
+    cummean
 
 
 class TestEval(unittest.TestCase):
@@ -18,42 +18,42 @@ class TestEval(unittest.TestCase):
         """Test valid and invalid inputs for scale_iou()."""
 
         # Identical boxes.
-        sa = EvalBox(size=[4, 4, 4])
-        sr = EvalBox(size=[4, 4, 4])
+        sa = EvalBox(size=(4, 4, 4))
+        sr = EvalBox(size=(4, 4, 4))
         res = scale_iou(sa, sr)
         self.assertEqual(res, 1)
 
         # SA is bigger.
-        sa = EvalBox(size=[2, 2, 2])
-        sr = EvalBox(size=[1, 1, 1])
+        sa = EvalBox(size=(2, 2, 2))
+        sr = EvalBox(size=(1, 1, 1))
         res = scale_iou(sa, sr)
         self.assertEqual(res, 1/8)
 
         # SR is bigger.
-        sa = EvalBox(size=[1, 1, 1])
-        sr = EvalBox(size=[2, 2, 2])
+        sa = EvalBox(size=(1, 1, 1))
+        sr = EvalBox(size=(2, 2, 2))
         res = scale_iou(sa, sr)
         self.assertEqual(res, 1/8)
 
         # Arbitrary values.
-        sa = EvalBox(size=[0.96, 0.37, 0.69])
-        sr = EvalBox(size=[0.32, 0.01, 0.39])
+        sa = EvalBox(size=(0.96, 0.37, 0.69))
+        sr = EvalBox(size=(0.32, 0.01, 0.39))
         res = scale_iou(sa, sr)
         self.assertAlmostEqual(res, 0.00509204)
 
         # One empty box.
-        sa = EvalBox(size=[0, 4, 4])
-        sr = EvalBox(size=[4, 4, 4])
+        sa = EvalBox(size=(0, 4, 4))
+        sr = EvalBox(size=(4, 4, 4))
         self.assertRaises(AssertionError, scale_iou, sa, sr)
 
         # Two empty boxes.
-        sa = EvalBox(size=[0, 4, 4])
-        sr = EvalBox(size=[4, 0, 4])
+        sa = EvalBox(size=(0, 4, 4))
+        sr = EvalBox(size=(4, 0, 4))
         self.assertRaises(AssertionError, scale_iou, sa, sr)
 
         # Negative sizes.
-        sa = EvalBox(size=[4, 4, 4])
-        sr = EvalBox(size=[4, -5, 4])
+        sa = EvalBox(size=(4, 4, 4))
+        sr = EvalBox(size=(4, -5, 4))
         self.assertRaises(AssertionError, scale_iou, sa, sr)
 
     def test_yaw_diff(self):
@@ -73,10 +73,10 @@ class TestEval(unittest.TestCase):
 
         # Misc sr yaws for fixed sa yaw.
         q0 = Quaternion(axis=(0, 0, 1), angle=0)
-        sa = EvalBox(rotation= q0.elements)
+        sa = EvalBox(rotation=q0.elements)
         for yaw_in in np.linspace(-10, 10, 100):
             q1 = Quaternion(axis=(0, 0, 1), angle=yaw_in)
-            sr = EvalBox(rotation= q1.elements)
+            sr = EvalBox(rotation=q1.elements)
             diff = yaw_diff(sa, sr)
             yaw_true = yaw_in % (2 * np.pi)
             if yaw_true > np.pi:
@@ -133,47 +133,47 @@ class TestEval(unittest.TestCase):
         """Test for center_distance()."""
 
         # Same boxes.
-        sa = EvalBox(translation=[4, 4, 5])
-        sr = EvalBox(translation=[4, 4, 5])
+        sa = EvalBox(translation=(4, 4, 5))
+        sr = EvalBox(translation=(4, 4, 5))
         self.assertAlmostEqual(center_distance(sa, sr), 0)
 
         # When no translation given
-        sa = EvalBox(size=[4, 4, 4])
-        sr = EvalBox(size=[3, 3, 3])
+        sa = EvalBox(size=(4, 4, 4))
+        sr = EvalBox(size=(3, 3, 3))
         self.assertAlmostEqual(center_distance(sa, sr), 0)
 
         # Different z translation (z should be ignored).
-        sa = EvalBox(translation=[4, 4, 4])
-        sr = EvalBox(translation=[3, 3, 3])
-        self.assertAlmostEqual(center_distance(sa, sr), np.sqrt(2))
+        sa = EvalBox(translation=(4, 4, 4))
+        sr = EvalBox(translation=(3, 3, 3))
+        self.assertAlmostEqual(center_distance(sa, sr), np.sqrt((3 - 4) ** 2 + (3 - 4) ** 2))
 
         # Negative values.
-        sa = EvalBox(translation=[-1, -1, -1])
-        sr = EvalBox(translation=[1, 1, 1])
-        self.assertAlmostEqual(center_distance(sa, sr), np.sqrt(8))
+        sa = EvalBox(translation=(-1, -1, -1))
+        sr = EvalBox(translation=(1, 1, 1))
+        self.assertAlmostEqual(center_distance(sa, sr), np.sqrt((1 + 1) ** 2 + (1 + 1) ** 2))
 
         # Arbitrary values.
-        sa = EvalBox(translation=[4.2, 2.8, 4.2])
-        sr = EvalBox(translation=[-1.45, 3.5, 3.9])
-        self.assertAlmostEqual(center_distance(sa, sr), 5.693197695)
+        sa = EvalBox(translation=(4.2, 2.8, 4.2))
+        sr = EvalBox(translation=(-1.45, 3.5, 3.9))
+        self.assertAlmostEqual(center_distance(sa, sr), np.sqrt((-1.45 - 4.2) ** 2 + (3.5 - 2.8) ** 2))
 
     def test_velocity_l2(self):
         """Test for velocity_l2()."""
 
         # Same velocity.
-        sa = EvalBox(velocity=[4, 4])
-        sr = EvalBox(velocity=[4, 4])
+        sa = EvalBox(velocity=(4, 4))
+        sr = EvalBox(velocity=(4, 4))
         self.assertAlmostEqual(velocity_l2(sa, sr), 0)
 
         # Negative values.
-        sa = EvalBox(velocity=[-1, -1])
-        sr = EvalBox(velocity=[1, 1])
-        self.assertAlmostEqual(velocity_l2(sa, sr), np.sqrt(8))
+        sa = EvalBox(velocity=(-1, -1))
+        sr = EvalBox(velocity=(1, 1))
+        self.assertAlmostEqual(velocity_l2(sa, sr), np.sqrt((1 + 1) ** 2 + (1 + 1) ** 2))
 
         # Arbitrary values.
-        sa = EvalBox(velocity=[8.2, 1.4])
-        sr = EvalBox(velocity=[6.4, -9.4])
-        self.assertAlmostEqual(velocity_l2(sa, sr), 10.94897255)
+        sa = EvalBox(velocity=(8.2, 1.4))
+        sr = EvalBox(velocity=(6.4, -9.4))
+        self.assertAlmostEqual(velocity_l2(sa, sr), np.sqrt((6.4 - 8.2) ** 2 + (-9.4 - 1.4) ** 2))
 
     def test_cummean(self):
         """Test for cummean()."""

--- a/python-sdk/nuscenes/eval/detection/utils.py
+++ b/python-sdk/nuscenes/eval/detection/utils.py
@@ -57,7 +57,7 @@ def detection_name_to_rel_attributes(detection_name: str) -> List[str]:
         # Classes without attributes: barrier, traffic_cone.
         rel_attributes = []
     else:
-        raise Exception('Error: %s is not a valid detection class.' % detection_name)
+        raise ValueError('Error: %s is not a valid detection class.' % detection_name)
 
     return rel_attributes
 


### PR DESCRIPTION
This adds some simple unit tests to check the correctness of the AP calculation. Modified the AP calculation to exclude the bin that is equal to `min_recall` value as discussed in the office. 

Now the `calc_ap` method returns nan value for `min_recall = 1.0` as we calculate average of precisions corresponding to `recall>min_recall` instead of `recall>=min_recall`.

I also cleaned up some old tests to avoid PEP8 warnings.