### PR TITLE
Unittests for true positive error metrics calculation

### DIFF
--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -182,7 +182,7 @@ def calc_ap(md: MetricData, min_recall: float, min_precision: float) -> float:
     assert 0 <= min_recall <= 1
 
     prec = np.copy(md.precision)
-    prec = prec[round(100 * min_recall) + 1:]  # Clip low recalls.
+    prec = prec[round(100 * min_recall) + 1:]  # Clip low recalls. +1 to exclude the min recall bin.
     prec -= min_precision  # Clip low precision
     prec[prec < 0] = 0
     return float(np.mean(prec)) / (1.0 - min_precision)
@@ -191,9 +191,9 @@ def calc_ap(md: MetricData, min_recall: float, min_precision: float) -> float:
 def calc_tp(md: MetricData, min_recall: float, metric_name: str) -> float:
     """ Calculates true positive errors. """
 
-    first_ind = round(100 * min_recall)
+    first_ind = round(100 * min_recall) + 1  # +1 to exclude the error at min recall.
     last_ind = md.max_recall_ind  # First instance of confidence = 0 is index of max achieved recall.
     if last_ind < first_ind:
         return 1.0  # Assign 1 here. If this happens for all classes, the score for that TP metric will be 0.
     else:
-        return float(np.mean(getattr(md, metric_name)[first_ind: last_ind]))
+        return float(np.mean(getattr(md, metric_name)[first_ind: last_ind + 1]))  # +1 to include error at max recall

--- a/python-sdk/nuscenes/eval/detection/main.py
+++ b/python-sdk/nuscenes/eval/detection/main.py
@@ -17,7 +17,7 @@ from nuscenes.eval.detection.constants import TP_METRICS
 from nuscenes.eval.detection.config import config_factory
 from nuscenes.eval.detection.data_classes import DetectionConfig, MetricDataList, DetectionMetrics
 from nuscenes.eval.detection.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
-from nuscenes.eval.detection.render import summary_plot, class_pr_curve, class_tp_curve, dist_pr_curve
+from nuscenes.eval.detection.render import summary_plot, class_pr_curve, class_tp_curve, dist_pr_curve, visualize_sample
 
 
 class NuScenesEval:
@@ -142,7 +142,7 @@ class NuScenesEval:
     def render(self, md_list: MetricDataList, metrics: DetectionMetrics):
 
         def savepath(name):
-            return os.path.join(self.plot_dir, name+'.png')
+            return os.path.join(self.plot_dir, name+'.pdf')
 
         summary_plot(md_list, metrics, min_precision=self.cfg.min_precision, min_recall=self.cfg.min_recall,
                      dist_th_tp=self.cfg.dist_th_tp, savepath=savepath('summary'))
@@ -174,16 +174,15 @@ def main():
     nusc_eval = NuScenesEval(nusc_, config=cfg, result_path=result_path, eval_set=eval_set, output_dir=output_dir,
                              verbose=verbose)
 
-    # # TODO: Add this back in once visualize_sample is updated.
-    # # Visualize samples.
-    # random.seed(43)
-    # plot_examples = bool(args.plot_examples)
-    # if plot_examples:
-    #     sample_tokens_ = list(nusc_eval.gt_boxes.keys())
-    #     random.shuffle(sample_tokens_)
-    #     for sample_token_ in sample_tokens_:
-    #         visualize_sample(nusc, sample_token_, nusc_eval.gt_boxes, nusc_eval.pred_boxes,
-    #                          eval_range=nusc_eval.cfg.eval_range)
+    # Visualize samples.
+    random.seed(43)
+    plot_examples = bool(args.plot_examples)
+    if plot_examples:
+        sample_tokens_ = list(nusc_eval.sample_tokens)
+        random.shuffle(sample_tokens_)
+        for sample_token_ in sample_tokens_:
+            visualize_sample(nusc_, sample_token_, nusc_eval.gt_boxes, nusc_eval.pred_boxes,
+                             eval_range=nusc_eval.cfg.class_range)
 
     # Run evaluation.
     metrics, md_list = nusc_eval.run()

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -8,6 +8,7 @@ import unittest
 from typing import Dict, List
 
 import numpy as np
+from pyquaternion import Quaternion
 
 from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp
 from nuscenes.eval.detection.config import config_factory
@@ -112,7 +113,7 @@ class TestAlgo(unittest.TestCase):
                     tp = calc_tp(metric_data, self.cfg.min_recall, metric_name)
                 metrics.add_label_tp(class_name, metric_name, tp)
 
-        self.assertEqual(0.0862032595184608, metrics.weighted_sum)
+        self.assertEqual(0.08606662159639042, metrics.weighted_sum)
 
     def test_calc_tp(self):
         """Test for calc_tp()."""
@@ -142,14 +143,59 @@ class TestAlgo(unittest.TestCase):
         self.assertRaises(AssertionError, calc_ap, md, 1.2, 0)
 
 
+def get_metric_data(gts: Dict[str, List[Dict]],
+                    preds: Dict[str, List[Dict]],
+                    detection_name: str,
+                    dist_th: float) -> MetricData:
+        """
+        Calculate and check the AP value.
+        :param gts: Ground truth data.
+        :param preds: Predictions.
+        :param detection_name: Name of the class we are interested in.
+        :param dist_th: Distance threshold for matching.
+        """
+
+        # Some or all of the defaults will be replaced by if given.
+        defaults = {'trans': (0, 0, 0), 'size': (1, 1, 1), 'rot': (0, 0, 0, 0),
+                    'vel': (0, 0), 'attr': 'vehicle.parked', 'score': -1.0, 'name': 'car'}
+        # Create GT EvalBoxes instance.
+        gt_eval_boxes = EvalBoxes()
+        for sample_token, data in gts.items():
+            gt_boxes = []
+            for gt in data:
+                gt = {**defaults, **gt}  # The defaults will be replaced by gt if given.
+                eb = EvalBox(sample_token=sample_token, translation=gt['trans'], size=gt['size'], rotation=gt['rot'],
+                             detection_name=gt['name'], attribute_name=gt['attr'], velocity=gt['vel'])
+                gt_boxes.append(eb)
+
+            gt_eval_boxes.add_boxes(sample_token, gt_boxes)
+
+        # Create Predictions EvalBoxes instance.
+        pred_eval_boxes = EvalBoxes()
+        for sample_token, data in preds.items():
+            pred_boxes = []
+            for pred in data:
+                pred = {**defaults, **pred}
+                eb = EvalBox(sample_token=sample_token, translation=pred['trans'], size=pred['size'],
+                             rotation=pred['rot'], detection_name=pred['name'], detection_score=pred['score'],
+                             velocity=pred['vel'], attribute_name=pred['attr'])
+                pred_boxes.append(eb)
+            pred_eval_boxes.add_boxes(sample_token, pred_boxes)
+
+        metric_data = accumulate(gt_eval_boxes, pred_eval_boxes, class_name=detection_name,
+                                 dist_fcn_name='center_distance', dist_th=dist_th)
+
+        return metric_data
+
+
 class TestAPSimple(unittest.TestCase):
     """ Tests the correctness of AP calculation for simple cases. """
 
     def setUp(self):
-        self.car1 = {'trans': (1, 1, 1), 'size': (2, 4, 2), 'rot': (0, 0, 0, 0), 'name': 'car', 'score': 1.0}
-        self.car2 = {'trans': (3, 3, 1), 'size': (2, 4, 2), 'rot': (0, 0, 0, 0), 'name': 'car', 'score': 0.7}
-        self.bicycle1 = {'trans': (5, 5, 1), 'size': (2, 2, 2), 'rot': (0, 0, 0, 0), 'name': 'bicycle', 'score': 1.0}
-        self.bicycle2 = {'trans': (7, 7, 1), 'size': (2, 2, 2), 'rot': (0, 0, 0, 0), 'name': 'bicycle', 'score': 0.7}
+        self.car1 = {'trans': (1, 1, 1), 'name': 'car', 'score': 1.0, }
+        self.car2 = {'trans': (3, 3, 1), 'name': 'car', 'score': 0.7}
+        self.bicycle1 = {'trans': (5, 5, 1), 'name': 'bicycle', 'score': 1.0}
+        self.bicycle2 = {'trans': (7, 7, 1), 'name': 'bicycle', 'score': 0.7}
 
     def check_ap(self, gts: Dict[str, List[Dict]],
                  preds: Dict[str, List[Dict]],
@@ -168,30 +214,7 @@ class TestAPSimple(unittest.TestCase):
         :param min_precision: Minimum precision value.
         :param min_recall: Minimum recall value.
         """
-        # Create GT EvalBoxes instance.
-        gt_eval_boxes = EvalBoxes()
-        for sample_token, data in gts.items():
-            gt_boxes = []
-            for gt in data:
-                eb = EvalBox(sample_token=sample_token, translation=gt['trans'], size=gt['size'], rotation=gt['rot'],
-                             detection_name=gt['name'])
-                gt_boxes.append(eb)
-
-            gt_eval_boxes.add_boxes(sample_token, gt_boxes)
-
-        # Create Predictions EvalBoxes instance.
-        pred_eval_boxes = EvalBoxes()
-        for sample_token, data in preds.items():
-            pred_boxes = []
-            for pred in data:
-                eb = EvalBox(sample_token=sample_token, translation=pred['trans'], size=pred['size'],
-                             rotation=pred['rot'], detection_name=pred['name'], detection_score=pred['score'])
-                pred_boxes.append(eb)
-            pred_eval_boxes.add_boxes(sample_token, pred_boxes)
-
-        metric_data = accumulate(gt_eval_boxes, pred_eval_boxes, class_name=detection_name,
-                                 dist_fcn_name='center_distance', dist_th=dist_th)
-
+        metric_data = get_metric_data(gts, preds, detection_name, dist_th)
         ap = calc_ap(metric_data, min_precision=min_precision, min_recall=min_recall)
 
         # We quantize the curve into 100 bins to calculate integral so the AP is accurate up to 1%.
@@ -213,8 +236,8 @@ class TestAPSimple(unittest.TestCase):
         # No predictions and no ground truth objects.
         self.check_ap(empty, empty, target_ap=0.0)
 
-    def test_one_img(self):
-        """ Test perfect detection. """
+    def test_one_sample(self):
+        """ Test the single sample case. """
         # Perfect detection.
         self.check_ap({'sample1': [self.car1]},
                       {'sample1': [self.car1]},
@@ -240,7 +263,8 @@ class TestAPSimple(unittest.TestCase):
                       {'sample1': [self.car1, self.bicycle1]},
                       target_ap=1.0, detection_name='car')
 
-    def test_two_imgs(self):
+    def test_two_samples(self):
+        """ Test more than one sample case. """
         # Objects in both samples are detected.
         self.check_ap({'sample1': [self.car1], 'sample2': [self.car2]},
                       {'sample1': [self.car1], 'sample2': [self.car2]},
@@ -255,6 +279,132 @@ class TestAPSimple(unittest.TestCase):
         self.check_ap({'sample1': [self.car1], 'sample2': [self.car2]},
                       {'sample1': [self.car1], 'sample2': []},
                       target_ap=0.4/0.9, detection_name='car')
+
+
+class TestTPSimple(unittest.TestCase):
+    """ Tests the correctness of true positives metrics calculation for simple cases. """
+
+    def setUp(self):
+
+        self.car3 = {'trans': (3, 3, 1), 'size': (2, 4, 2), 'rot': Quaternion(axis=(0, 0, 1), angle=0), 'score': 1.0}
+        self.car4 = {'trans': (3, 3, 1), 'size': (2, 4, 2), 'rot': Quaternion(axis=(0, 0, 1), angle=0), 'score': 1.0}
+
+    def check_tp(self, gts: Dict[str, List[Dict]],
+                 preds: Dict[str, List[Dict]],
+                 target_error: float,
+                 metric_name: str,
+                 detection_name: str = 'car',
+                 min_recall: float = 0.1):
+        """
+        Calculate and check the AP value.
+        :param gts: Ground truth data.
+        :param preds: Predictions.
+        :param target_error: Expected error value.
+        :param metric_name: Name of the TP metric.
+        :param detection_name: Name of the class we are interested in.
+        :param min_recall: Minimum recall value.
+        """
+
+        metric_data = get_metric_data(gts, preds, detection_name, 2.0)  # Distance threshold for TP metrics is 2.0
+        tp_error = calc_tp(metric_data, min_recall=min_recall, metric_name=metric_name)
+        # We quantize the error curve into 100 bins to calculate the metric so it is only accurate up to 1%.
+        self.assertGreaterEqual(0.01, abs(tp_error - target_error), msg='Incorrect {} value'.format(metric_name))
+
+    def test_no_positives(self):
+        """ Tests the error if there are no matches. The expected behaviour is to return error of 1.0. """
+
+        # Same type of objects but are more than 2m away.
+        car1 = {'trans': (1, 1, 1), 'score': 1.0}
+        car2 = {'trans': (3, 3, 1), 'score': 1.0}
+        bike1 = {'trans': (1, 1, 1), 'score': 1.0, 'name': 'bicycle', 'attr': 'cycle.with_rider'}
+        for metric_name in TP_METRICS:
+            self.check_tp({'sample1': [car1]}, {'sample1': [car2]}, target_error=1.0, metric_name=metric_name)
+
+        # Within distance threshold away but different classes.
+        for metric_name in TP_METRICS:
+            self.check_tp({'sample1': [car1]}, {'sample1': [bike1]}, target_error=1.0, metric_name=metric_name)
+
+    def test_perfect(self):
+        """ Tests when everything is estimated perfectly. """
+
+        car1 = {'trans': (1, 1, 1), 'score': 1.0}
+        car2 = {'trans': (1, 1, 1), 'score': 0.3}
+        for metric_name in TP_METRICS:
+            # Detected with perfect score.
+            self.check_tp({'sample1': [car1]}, {'sample1': [car1]}, target_error=0.0, metric_name=metric_name)
+
+            # Detected with low score.
+            self.check_tp({'sample1': [car1]}, {'sample1': [car2]}, target_error=0.0, metric_name=metric_name)
+
+    def test_one_img(self):
+        """ Test single sample case. """
+
+        # Note all the following unit tests can be repeated to other metrics, but they are not needed.
+        # The intention of these tests is to measure the calc_tp function which is common for all metrics.
+
+        gt1 = {'trans': (1, 1, 1)}
+        gt2 = {'trans': (10, 10, 1), 'size': (2, 2, 2)}
+        gt3 = {'trans': (20, 20, 1), 'size': (2, 4, 2)}
+
+        pred1 = {'trans': (1, 1, 1), 'score': 1.0}
+        pred2 = {'trans': (11, 10, 1), 'size': (2, 2, 2), 'score': 0.9}
+        pred3 = {'trans': (100, 10, 1), 'size': (2, 2, 2), 'score': 0.8}
+        pred4 = {'trans': (20, 20, 1), 'size': (2, 4, 2), 'score': 0.7}
+        pred5 = {'trans': (21, 20, 1), 'size': (2, 4, 2), 'score': 0.7}
+
+        # One GT and one detection
+        self.check_tp({'sample1': [gt2]}, {'sample1': [pred2]}, target_error=1, metric_name='trans_err')
+
+        # Two GT's and two detections.
+        # The target is the average value of the recall vs. Error curve.
+        target_error = ((0 + 0) / 2 + (0 + 0.5) / 2) / (2 * 0.9)  # It is a piecewise linear with 2 segments.
+        self.check_tp({'sample1': [gt1, gt2]}, {'sample1': [pred1, pred2]}, target_error=target_error,
+                      metric_name='trans_err')
+
+        # Adding a false positive with smaller detection score should not affect the true positive metric.
+        self.check_tp({'sample1': [gt1, gt2]}, {'sample1': [pred1, pred2, pred3]}, target_error=target_error,
+                      metric_name='trans_err')
+
+        target_error = ((0+0)/2 + (0+0.5)/2 + (0.5 + 0.33)/2) / (3 * 0.9)  # It is a piecewise linear with 3 segments
+        self.check_tp({'sample1': [gt1, gt2, gt3]}, {'sample1': [pred1, pred2, pred4]}, target_error=target_error,
+                      metric_name='trans_err')
+
+        # All the detections does have same error, so the overall error is also same.
+        self.check_tp({'sample1': [gt2, gt3]}, {'sample1': [pred2, pred5]}, target_error=1.0,
+                      metric_name='trans_err')
+
+    def test_two_imgs(self):
+        """ Test the more than one sample case. """
+
+        # Note all the following unit tests can be repeated to other metrics, but they are not needed.
+        # The intention of these tests is to measure the calc_tp function which is common for all metrics.
+
+        gt1 = {'trans': (1, 1, 1)}
+        gt2 = {'trans': (10, 10, 1), 'size': (2, 2, 2)}
+        gt3 = {'trans': (20, 20, 1), 'size': (2, 4, 2)}
+
+        pred1 = {'trans': (1, 1, 1), 'score': 1.0}
+        pred2 = {'trans': (11, 10, 1), 'size': (2, 2, 2), 'score': 0.9}
+        pred3 = {'trans': (100, 10, 1), 'size': (2, 2, 2), 'score': 0.8}
+        pred4 = {'trans': (21, 20, 1), 'size': (2, 4, 2), 'score': 0.7}
+
+        # One GT and one detection
+        self.check_tp({'sample1': [gt2]}, {'sample1': [pred2]}, target_error=1, metric_name='trans_err')
+
+        # Two GT's and two detections.
+        # The target is the average value of the recall vs. Error curve.
+        target_error = ((0 + 0) / 2 + (0 + 0.5) / 2) / (2 * 0.9)  # It is a piecewise linear with 2 segments.
+        self.check_tp({'sample1': [gt1], 'sample2': [gt2]}, {'sample1': [pred1], 'sample2': [pred2]},
+                      target_error=target_error, metric_name='trans_err')
+
+        # Adding a false positive and/or an empty sample should not affect the score
+        self.check_tp({'sample1': [gt1], 'sample2': [gt2], 'sample3': []},
+                      {'sample1': [pred1], 'sample2': [pred2, pred3], 'sample3': []},
+                      target_error=target_error, metric_name='trans_err')
+
+        # All the detections does have same error, so the overall error is also same.
+        self.check_tp({'sample1': [gt2, gt3], 'sample2': [gt3]}, {'sample1': [pred2], 'sample2': [pred4]},
+                      target_error=1.0, metric_name='trans_err')
 
 
 if __name__ == '__main__':

--- a/python-sdk/nuscenes/eval/detection/tests/test_main.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_main.py
@@ -115,7 +115,8 @@ class TestMain(unittest.TestCase):
         # 6. Score = 0.20636954644294506. After bike-rack filtering.
         # 7. Score = 0.20237925145690996. After TP reversion bug.
         # 8. Score = 0.24047129251302665. After bike racks bug.
-        self.assertAlmostEqual(metrics.weighted_sum, 0.24047129251302665)
+        # 9. Score = 0.24104572227466886. After bug fix in calc_tp. Include the max recall and exclude the min recall.
+        self.assertAlmostEqual(metrics.weighted_sum, 0.24104572227466886)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds some unit tests to check the correctness of the TP metric calculation. 

I had to change the regression test score (and one other regression test) because of a minor bug fix in `calc_tp` method.

Please have a look and let me know if anything doesn't make sense, thanks.