### PR TITLE
Export 2d annotations

### DIFF
--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -242,7 +242,7 @@ def get_2d_boxes(sample_data_token: str) -> List[OrderedDict]:
         box.translate(-np.array(cs_rec['translation']))
         box.rotate(Quaternion(cs_rec['rotation']).inverse)
 
-        if not box_in_image(box, camera_intrinsic, (1600, 900), BoxVisibility.Any):
+        if not box_in_image(box, camera_intrinsic, (1600, 900), BoxVisibility.ANY):
             continue
 
         corner_coords = view_points(box.corners(), camera_intrinsic, True)

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -15,15 +15,24 @@ import json
 import argparse
 import os
 
-from typing import List, Tuple
+from typing import List
 from pyquaternion.quaternion import Quaternion
 from shapely.geometry import LineString, Point
 from collections import OrderedDict
 from tqdm import tqdm
+from nuscenes.utils.geometry_utils import BoxVisibility
 
 
 class Corner:
-    def __init__(self, point: Point, min_x=0, max_x=1600, min_y=0, max_y=900):
+    """A data class implementing a 3d bounding box corner"""
+    def __init__(self, point: Point, min_x: float = 0, max_x: float = 1600, min_y: float = 0, max_y: float = 900):
+        """
+        :param point: A shapely implementation of a point using.
+        :param min_x: Minimum value of x in the image coordinate.
+        :param max_x: Maximum value of x in the image coordinate.
+        :param min_y: Minimum value of y in the image coordinate.
+        :param max_y: Maixmum value of y in the image coordinate.
+        """
         self.point = point
         self.min_x = min_x
         self.max_x = max_x
@@ -33,36 +42,73 @@ class Corner:
         self.x = self.point.x
         self.y = self.point.y
 
-    def is_inside_image(self):
-        return (self.min_x < self.x < self.max_x) and (self.min_y < self.y < self.min_y)
+    def is_inside_image(self) -> bool:
+        """
+        Returns `True` if the box is inside the image canvas, `False` otherwise.
+        :return: Whether the box is inside the image.
+        """
+        return (self.min_x - 0.5 < self.x < self.max_x + 0.5) and (self.min_y - 0.5 < self.y < self.max_y + 0.5)
 
 
-class Segment:
-    def __init__(self, line_string: LineString, min_x=0, max_x=1600, min_y=0, max_y=900):
+class Line:
+    """A data class implementing a 3d bounding box line segment"""
+    def __init__(self,
+                 line_string: LineString,
+                 min_x: float = 0,
+                 max_x: float = 1600,
+                 min_y: float = 0,
+                 max_y: float = 900):
+        """
+        :param line_string: A shapely implementation of a line string.
+        :param min_x: Minimum value of x in the image coordinate.
+        :param max_x: Maximum value of x in the image coordinate.
+        :param min_y: Minimum value of y in the image coordinate.
+        :param max_y: Maximum value of y in the image coordinate.
+        """
         self.line_string = line_string
         self.min_x = min_x
         self.max_x = max_x
         self.min_y = min_y
         self.max_y = max_y
 
-        self.right_boundary = LineString([(max_x, min_y), (max_x, max_y)])
         self.left_boundary = LineString([(min_x, min_y), (min_x, max_y)])
+        self.right_boundary = LineString([(max_x, min_y), (max_x, max_y)])
         self.top_boundary = LineString([(min_x, min_y), (max_x, min_y)])
         self.bottom_boundary = LineString([(min_x, max_y), (max_x, max_y)])
 
-    def is_left_intersect(self):
+    def is_left_intersect(self) -> bool:
+        """
+        Returns True if the line segment intersects the left boundary of the image, False otherwise
+        :return: Whether the line segment intersects the left boundary of the image
+        """
         return self.line_string.intersects(self.left_boundary)
 
-    def is_right_intersect(self):
+    def is_right_intersect(self) -> bool:
+        """
+        Returns True if the line segment intersects the right boundary of the image, False otherwise
+        :return: Whether the line segment intersects the right boundary of the image
+        """
         return self.line_string.intersects(self.right_boundary)
 
-    def is_top_intersect(self):
+    def is_top_intersect(self) -> bool:
+        """
+        Returns True if the line segment intersects the top boundary of the image, False otherwise
+        :return: Whether the line segment intersects the top boundary of the image
+        """
         return self.line_string.intersects(self.top_boundary)
 
-    def is_bottom_intersect(self):
+    def is_bottom_intersect(self) -> bool:
+        """
+        Returns True if the line segment intersects the top boundary of the image, False otherwise
+        :return: Whether the line segment intersects the top boundary of the image
+        """
         return self.line_string.intersects(self.bottom_boundary)
 
-    def boundary_intersections(self):
+    def boundary_intersections(self) -> List[Corner]:
+        """
+        Retrieve all the intersections points with the image boundaries.
+        :return: Intersection points with the image boundaries.
+        """
         intersections = []
         if self.is_left_intersect():
             intersections.append(Corner(self.line_string.intersection(self.left_boundary)))
@@ -97,12 +143,21 @@ def generate_record(ann_rec: dict,
     repro_rec = OrderedDict()
     repro_rec['sample_data_token'] = sample_data_token
 
-    ignored_keys = ['rotation', 'sample_token', 'size', 'token', 'translation']
+    relevant_keys = [
+        'attribute_tokens',
+        'category_name',
+        'instance_token',
+        'next',
+        'num_lidar_pts',
+        'num_radar_pts',
+        'prev',
+        'sample_annotation_token',
+        'sample_data_token',
+        'visibility_token',
+    ]
 
     for key, value in ann_rec.items():
-        if key in ignored_keys:
-            pass
-        else:
+        if key in relevant_keys:
             repro_rec[key] = value
 
     repro_rec['bbox_corners'] = [x1, y1, x2, y2]
@@ -111,33 +166,35 @@ def generate_record(ann_rec: dict,
     return repro_rec
 
 
-def get_line_segments(corners: np.ndarray) -> List[Segment]:
+def get_line_segments(corners: np.ndarray) -> List[Line]:
     """
-    Draw the 2d bounding boxes, extra logic to handle the case where the 3d box extends outside the image.
-    :param corners: Corners
-    :return:
+    Get all the line segments that corresponds to the corners of the bounding box.
+    :param corners: Corners of the bounding box.
+    :return: Line segments of a particular bounding box.
     """
 
     lines = []
-    front_corners = corners[:4]
+    front_corners = corners.T[4:]
     prev = front_corners[-1]
     for corner in front_corners:
         x1 = prev[0]
         y1 = prev[1]
         x2 = corner[0]
         y2 = corner[1]
+        prev = corner
 
-        lines.append(Segment(LineString([(x1, y1), (x2, y2)])))
+        lines.append(Line(LineString([(x1, y1), (x2, y2)])))
 
-    rear_corners = corners[:4]
+    rear_corners = corners.T[:4]
     prev = rear_corners[-1]
     for corner in rear_corners:
         x1 = prev[0]
         y1 = prev[1]
         x2 = corner[0]
         y2 = corner[1]
+        prev = corner
 
-        lines.append(Segment(LineString([(x1, y1), (x2, y2)])))
+        lines.append(Line(LineString([(x1, y1), (x2, y2)])))
 
     for i in range(4):
         x1 = corners.T[i][0]
@@ -145,7 +202,7 @@ def get_line_segments(corners: np.ndarray) -> List[Segment]:
         x2 = corners.T[i + 4][0]
         y2 = corners.T[i + 4][1]
 
-        lines.append(Segment(LineString([(x1, y1), (x2, y2)])))
+        lines.append(Line(LineString([(x1, y1), (x2, y2)])))
 
     return lines
 
@@ -157,18 +214,16 @@ def get_2d_boxes(sample_data_token: str) -> List[OrderedDict]:
     :return: List of 2D annotation record that belongs to the input `sample_data_token`
     """
 
-    # Get the sample data, and the sample corresponding to that sample data
+    # Get the sample data, and the sample corresponding to that sample data.
     sd_rec = nusc.get('sample_data', sample_data_token)
-    if not (sd_rec['is_key_frame']):
-        raise ValueError("Selected sample data token is not a keyframe")
     s_rec = nusc.get('sample', sd_rec['sample_token'])
 
-    # Get the calibrated sensor and ego pose record to get the transformation matrices
+    # Get the calibrated sensor and ego pose record to get the transformation matrices.
     cs_rec = nusc.get('calibrated_sensor', sd_rec['calibrated_sensor_token'])
     pose_rec = nusc.get('ego_pose', sd_rec['ego_pose_token'])
     camera_intrinsic = np.array(cs_rec['camera_intrinsic'])
 
-    # Get all the annotation with above a visibility threshold
+    # Get all the annotation above a visibility threshold.
     ann_recs = [nusc.get('sample_annotation', token) for token in s_rec['anns']]
     ann_recs = [ann_rec for ann_rec in ann_recs if (ann_rec['visibility_token'] in args.visibilities)]
 
@@ -187,12 +242,13 @@ def get_2d_boxes(sample_data_token: str) -> List[OrderedDict]:
         box.translate(-np.array(cs_rec['translation']))
         box.rotate(Quaternion(cs_rec['rotation']).inverse)
 
-        if not box_in_image(box, camera_intrinsic, (1600, 900), 1):
+        if not box_in_image(box, camera_intrinsic, (1600, 900), BoxVisibility.Any):
             continue
 
         corner_coords = view_points(box.corners(), camera_intrinsic, True)
         segments = get_line_segments(corner_coords)
-        corners = [Corner(Point(corner_coord[0], corner_coord[1])) for corner_coord in corner_coords]
+        corners = [Corner(Point(corner_coord[0], corner_coord[1])) for corner_coord in corner_coords.T]
+
         for segment in segments:
             corners.extend(segment.boundary_intersections())
 
@@ -210,10 +266,14 @@ def get_2d_boxes(sample_data_token: str) -> List[OrderedDict]:
 
 
 def main():
-    sample_data_camera_tokens = [s['token'] for s in nusc.sample_data if
-                                 (s['sensor_modality'] == 'camera') and s['is_key_frame']]
+    if args.keyframes_only:
+        sample_data_camera_tokens = [s['token'] for s in nusc.sample_data if
+                                     (s['sensor_modality'] == 'camera') and s['is_key_frame']]
+    else:
+        sample_data_camera_tokens = [s['token'] for s in nusc.sample_data if (s['sensor_modality'] == 'camera')]
 
     print("Generating 2d reprojections of the nuScenes dataset")
+
     reprojections = []
     for token in tqdm(sample_data_camera_tokens):
         reprojection_records = get_2d_boxes(token)
@@ -222,16 +282,17 @@ def main():
     if not os.path.exists(args.dest_path):
         os.makedirs(args.dest_path)
 
-    with open('{}.json'.format(os.path.join(args.dest_path, args.version)), 'w') as fh:
+    with open(os.path.join(args.dataroot, args.version, args.dest_filename), 'w') as fh:
         json.dump(reprojections, fh, sort_keys=True, indent=4)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Export 2D annotations from reprojections to a .json file.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--keyframes_only', type=int, default=True)
     parser.add_argument('--dataroot', type=str, default='/data/sets/nuscenes')
-    parser.add_argument('--version', type=str, default='v1.0-trainval')
-    parser.add_argument('--dest_path', type=str, default='./2D_annotations/')
+    parser.add_argument('--version', type=str, default='v1.0')
+    parser.add_argument('--dest_filename', type=str, default='image_annotations.json')
     parser.add_argument('--visibilities', type=str, default=['2', '3', '4'])
     args = parser.parse_args()
 

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -99,8 +99,8 @@ class Line:
 
     def is_bottom_intersect(self) -> bool:
         """
-        Returns True if the line segment intersects the top boundary of the image, False otherwise
-        :return: Whether the line segment intersects the top boundary of the image
+        Returns True if the line segment intersects the bottom boundary of the image, False otherwise
+        :return: Whether the line segment intersects the bottom boundary of the image
         """
         return self.line_string.intersects(self.bottom_boundary)
 
@@ -279,10 +279,11 @@ def main():
         reprojection_records = get_2d_boxes(token)
         reprojections.extend(reprojection_records)
 
-    if not os.path.exists(args.dest_path):
-        os.makedirs(args.dest_path)
+    dest_path = os.path.join(args.dataroot, args.version)
+    if not os.path.exists(dest_path):
+        os.makedirs(dest_path)
 
-    with open(os.path.join(args.dataroot, args.version, args.dest_filename), 'w') as fh:
+    with open(os.path.join(args.dataroot, args.version, args.filename), 'w') as fh:
         json.dump(reprojections, fh, sort_keys=True, indent=4)
 
 
@@ -291,7 +292,7 @@ if __name__ == '__main__':
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--keyframes_only', type=int, default=True)
     parser.add_argument('--dataroot', type=str, default='/data/sets/nuscenes')
-    parser.add_argument('--version', type=str, default='v1.0')
+    parser.add_argument('--version', type=str, default='v1.0-trainval')
     parser.add_argument('--dest_filename', type=str, default='image_annotations.json')
     parser.add_argument('--visibilities', type=str, default=['2', '3', '4'])
     args = parser.parse_args()

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -293,7 +293,7 @@ if __name__ == '__main__':
     parser.add_argument('--keyframes_only', type=int, default=True)
     parser.add_argument('--dataroot', type=str, default='/data/sets/nuscenes')
     parser.add_argument('--version', type=str, default='v1.0-trainval')
-    parser.add_argument('--dest_filename', type=str, default='image_annotations.json')
+    parser.add_argument('--filename', type=str, default='image_annotations.json')
     parser.add_argument('--visibilities', type=str, default=['2', '3', '4'])
     args = parser.parse_args()
 

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -3,17 +3,19 @@
 # Licensed under the Creative Commons [see license.txt]
 
 """
-Export 2D annotations from re-projections of our annotated 3D bounding boxes to a .json file.
+Export 2D annotations (xmin, ymin,xmax, ymax) from re-projections of our annotated 3D bounding boxes to a .json file.
 """
 
 from nuscenes.nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import view_points
 from nuscenes.utils.geometry_utils import box_in_image
 
-from typing import List
 import numpy as np
 import json
 import argparse
+import os
+
+from typing import List
 from pyquaternion.quaternion import Quaternion
 from collections import OrderedDict
 from tqdm import tqdm
@@ -115,7 +117,10 @@ def main():
         reprojection_records = get_2d_boxes(token)
         reprojections.extend(reprojection_records)
 
-    with open('test.json', 'w') as fh:
+    if not os.path.exists(args.dest_path):
+        os.makedirs(args.dest_path)
+
+    with open('{}.json'.format(os.path.join(args.dest_path, args.version)), 'w') as fh:
         json.dump(reprojections, fh, sort_keys=True, indent=4)
 
 
@@ -124,7 +129,7 @@ if __name__ == '__main__':
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--dataroot', type=str, default='/data/sets/nuscenes')
     parser.add_argument('--version', type=str, default='v1.0-trainval')
-    parser.add_argument('--dest_path', type=str, default='v1.0-trainval-2D-box.json')
+    parser.add_argument('--dest_path', type=str, default='./2D_annotations/')
     parser.add_argument('--visibilities', type=str, default=['2', '3', '4'])
     args = parser.parse_args()
 

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -187,7 +187,7 @@ if __name__ == '__main__':
     parser.add_argument('--version', type=str, default='v1.0-trainval', help='Dataset version.')
     parser.add_argument('--filename', type=str, default='image_annotations.json', help='Output filename.')
     parser.add_argument('--visibilities', type=str, default=['1', '2', '3', '4'],
-                        help='Visibility bins, the higher the number the higher the visibility.')
+                        help='Visibility bins, the higher the number the higher the visibility.', nargs='+')
     args = parser.parse_args()
 
     nusc = NuScenes(dataroot=args.dataroot, version=args.version)

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -1,0 +1,186 @@
+from nuscenes.nuscenes import NuScenes
+from nuscenes.utils.geometry_utils import BoxVisibility
+from nuscenes.utils.geometry_utils import view_points
+import numpy as np
+import cv2
+from nuscenes.utils.data_classes import Box
+from pyquaternion.quaternion import Quaternion
+from collections import OrderedDict
+import os
+from tqdm import tqdm
+import json
+import argparse
+
+
+def get_color(category_name):
+    """
+    Provides the default colors based on the category names.
+    :param category_name: Name of the category (must be in the relevant classes)
+    """
+    if category_name in ['vehicle.bicycle', 'vehicle.motorcycle']:
+        return 255, 61, 99  # Red
+    elif 'vehicle' in category_name:
+        return 255, 158, 0  # Orange
+    elif 'human.pedestrian' in category_name:
+        return 0, 0, 230  # Blue
+    elif 'cone' in category_name or 'barrier' in category_name:
+        return 0, 0, 0  # Black
+    else:
+        return 255, 0, 255  # Magenta
+
+
+def box_in_image(box, intrinsic: np.ndarray, imsize: tuple, vis_level: int = BoxVisibility.ANY) -> bool:
+    """
+    Check if a box is visible inside an image without accounting for occlusions.
+    :param box: The box to be checked.
+    :param intrinsic: <float: 3, 3>. Intrinsic camera matrix.
+    :param imsize: (width, height).
+    :param vis_level: One of the enumerations of <BoxVisibility>.
+    :return True if visibility condition is satisfied.
+    """
+
+    corners_3d = box.corners()
+    corners_img = view_points(corners_3d, intrinsic, normalize=True)[:2, :]
+
+    visible = np.logical_and(corners_img[0, :] > 0, corners_img[0, :] < imsize[0])
+    visible = np.logical_and(visible, corners_img[1, :] < imsize[1])
+    visible = np.logical_and(visible, corners_img[1, :] > 0)
+    visible = np.logical_and(visible, corners_3d[2, :] > 1)
+
+    in_front = corners_3d[2, :] > 0.1  # True if a corner is at least 0.1 meter in front of the camera.
+
+    if vis_level == BoxVisibility.ALL:
+        return all(visible) and all(in_front)
+    elif vis_level == BoxVisibility.ANY:
+        return any(visible) and all(in_front)
+    elif vis_level == BoxVisibility.NONE:
+        return True
+    else:
+        raise ValueError("vis_level: {} not valid".format(vis_level))
+
+
+def get_box(sample_annotation_token: str):
+    """
+    Instantiates a Box class from a sample annotation record.
+    :param sample_annotation_token: Unique sample_annotation identifier.
+    """
+    record = nusc.get('sample_annotation', sample_annotation_token)
+    return Box(record['translation'], record['size'], Quaternion(record['rotation']),
+               name=record['category_name'], token=record['token'])
+
+
+def generate_record(ann_rec, x1, y1, x2, y2, sample_data_token, filename):
+    """
+    Generate one 2d annotation record .
+    :param ann_rec: Original 3d annotation record.
+    :param x1: Minimum value of the x coordinate.
+    :param y1: Minimum value of the y coordinate.
+    :param x2: Maximum value of the x coordinate.
+    :param y2: Maximum value of the y coordinate.
+    :param sample_data_token: Sample data tolk
+    :param filename:
+    :return:
+    """
+    repro_rec = OrderedDict()
+    repro_rec['sample_data_token'] = sample_data_token
+
+    ignored_keys = ['rotation', 'sample_token', 'size', 'token', 'translation']
+
+    for key, value in ann_rec.items():
+        if key in ignored_keys:
+            pass
+        else:
+            repro_rec[key] = value
+
+    repro_rec['bbox_corners'] = [x1, y1, x2, y2]
+    repro_rec['filename'] = filename
+
+    return repro_rec
+
+
+def get_2d_boxes(sample_data_token):
+    """
+    Get the 2d annotation records for a given `sample_data_token`.
+    :param sample_data_token: Sample data token belonging to a keyframe.
+    :return: List of 2d annotation record that belongs to the input `sample_data_token`
+    """
+    # Get the sample data, and the sample corresponding to that sample data
+    sd_rec = nusc.get('sample_data', sample_data_token)
+    if not (sd_rec['is_key_frame']):
+        raise ValueError("Selected sample data token is not a keyframe")
+    s_rec = nusc.get('sample', sd_rec['sample_token'])
+
+    # Get the calibrated sensor and ego pose record to get the transformation matrices
+    cs_rec = nusc.get('calibrated_sensor', sd_rec['calibrated_sensor_token'])
+    pose_rec = nusc.get('ego_pose', sd_rec['ego_pose_token'])
+    camera_intrinsic = np.array(cs_rec['camera_intrinsic'])
+
+    # Get all the annotation with above a visibility threshold
+    ann_recs = [nusc.get('sample_annotation', token) for token in s_rec['anns']]
+    ann_recs = [ann_rec for ann_rec in ann_recs if (ann_rec['visibility_token'] in args.visibilities)]
+
+    # Load the image data
+    data_path = os.path.join(nusc.dataroot, sd_rec['filename'])
+    img = cv2.imread(data_path)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+    repro_recs = []
+    for ann_rec in ann_recs:
+
+        ann_rec['sample_annotation_token'] = ann_rec['token']
+        ann_rec['sample_data_token'] = sample_data_token
+
+        box = get_box(ann_rec['token'])
+
+        box.translate(-np.array(pose_rec['translation']))
+        box.rotate(Quaternion(pose_rec['rotation']).inverse)
+
+        box.translate(-np.array(cs_rec['translation']))
+        box.rotate(Quaternion(cs_rec['rotation']).inverse)
+
+        if not box_in_image(box, camera_intrinsic, (1600, 900), 1):
+            continue
+
+        c = get_color(box.name)
+
+        corners = view_points(box.corners(), camera_intrinsic, True)
+        max_x = max(corners[0])
+        min_x = min(corners[0])
+        max_y = max(corners[1])
+        min_y = min(corners[1])
+
+        img = cv2.rectangle(img, (int(min_x), int(min_y)), (int(max_x), int(max_y)), c, 2)
+
+        repro_rec = generate_record(ann_rec, min_x, min_y, max_x, max_y, sample_data_token, sd_rec['filename'])
+        repro_recs.append(repro_rec)
+
+    return repro_recs
+
+
+def main():
+    sample_data_camera_tokens = [s['token'] for s in nusc.sample_data if
+                                 (s['sensor_modality'] == 'camera') and s['is_key_frame']]
+
+    print("Generating 2d reprojections of the nuScenes dataset")
+    reprojections = []
+    for token in tqdm(sample_data_camera_tokens):
+        reprojection_records = get_2d_boxes(token)
+        reprojections.extend(reprojection_records)
+
+    with open('test.json', 'w') as fh:
+        json.dump(reprojections, fh, sort_keys=True, indent=4)
+
+    return reprojections
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataroot', type=str, default='/data/sets/nuscenes')
+    parser.add_argument('--version', type=str, default='v1.0-trainval')
+    parser.add_argument('--dest_path', type=str, default='v1.0_2d_bbox.json')
+    parser.add_argument('--visibilities', type=str, default=['2', '3', '4'])
+    args = parser.parse_args()
+
+    nusc = NuScenes(dataroot=args.dataroot, version=args.version)
+    main()
+

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -29,7 +29,7 @@ def generate_record(ann_rec: dict,
                     sample_data_token: str,
                     filename: str) -> OrderedDict:
     """
-    Generate one 2d annotation record .
+    Generate one 2D annotation record given various informations on top of the 2D bounding box coordinates.
     :param ann_rec: Original 3d annotation record.
     :param x1: Minimum value of the x coordinate.
     :param y1: Minimum value of the y coordinate.
@@ -37,7 +37,7 @@ def generate_record(ann_rec: dict,
     :param y2: Maximum value of the y coordinate.
     :param sample_data_token: Sample data tolk
     :param filename:
-    :return:
+    :return: A sample 2D annotation record.
     """
     repro_rec = OrderedDict()
     repro_rec['sample_data_token'] = sample_data_token
@@ -58,9 +58,9 @@ def generate_record(ann_rec: dict,
 
 def get_2d_boxes(sample_data_token: str) -> List[OrderedDict]:
     """
-    Get the 2d annotation records for a given `sample_data_token`.
+    Get the 2D annotation records for a given `sample_data_token`.
     :param sample_data_token: Sample data token belonging to a keyframe.
-    :return: List of 2d annotation record that belongs to the input `sample_data_token`
+    :return: List of 2D annotation record that belongs to the input `sample_data_token`
     """
 
     # Get the sample data, and the sample corresponding to that sample data

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn==0.19.2
 tqdm==4.25.0
 scipy==1.1.0
 cachetools==3.1.0
+Shapely==1.6.4.post2


### PR DESCRIPTION
This PR adds the script to produce 2d annotations that are **re-projected from our 3d boxes** in the form of a .json file.

The details of the post processing steps are as follows:
1. Retrieve the corners of the 3D bounding box that is in front of the camera.
2. Used the convex hull of the corners.
3. Retrieve the intersecting polygons.
4. Bounding box corners is decided from the intersecting polygons

Sample renderings of the re-projected 2d annotations:
![image](https://user-images.githubusercontent.com/46339400/55851152-1a844000-5b8a-11e9-8d9b-a74962f136a7.png)
![image](https://user-images.githubusercontent.com/46339400/55851159-25d76b80-5b8a-11e9-9be6-a3cb855d017f.png)
![image](https://user-images.githubusercontent.com/46339400/55851177-338cf100-5b8a-11e9-9d51-1d94af201d5d.png)
![image](https://user-images.githubusercontent.com/46339400/55851190-3c7dc280-5b8a-11e9-9e29-fa320596d1ae.png)
