### PR TITLE
Removed legacy map binarize

### DIFF
--- a/python-sdk/nuscenes/utils/map_mask.py
+++ b/python-sdk/nuscenes/utils/map_mask.py
@@ -110,8 +110,6 @@ class MapMask:
         size_y = int(img.size[1] / self.resolution * native_resolution)
         img = img.resize((size_x, size_y), resample=Image.NEAREST)
 
-        # Convert to numpy and binarize.
+        # Convert to numpy.
         raw_mask = np.array(img)
-        raw_mask[raw_mask < 225] = self.background
-        raw_mask[raw_mask >= 225] = self.foreground
         return raw_mask


### PR DESCRIPTION
Now that the new maps are stored as [0, 255], we don't need the explicit conversion. This PR simply gets rid of them. I have checked the `render_egoposes_on_map()` method and it works the same as before. 