### PR TITLE
Re-added simple config factory

### DIFF
--- a/python-sdk/nuscenes/eval/detection/config.py
+++ b/python-sdk/nuscenes/eval/detection/config.py
@@ -1,0 +1,30 @@
+# nuScenes dev-kit.
+# Code written by Holger Caesar, 2019.
+# Licensed under the Creative Commons [see licence.txt]
+
+import json
+import os
+
+from nuscenes.eval.detection.data_classes import DetectionConfig
+
+
+def config_factory(configuration_name: str) -> DetectionConfig:
+    """
+    Creates a DetectionConfig instance that can be used to initialize a NuScenesEval instance.
+    Note that this only works if the config file is located in the nuscenes/eval/detection/configs folder.
+    :param configuration_name: Name of desired configuration in eval_detection_configs.
+    :return: DetectionConfig instance.
+    """
+
+    # Check if config exists.
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    cfg_path = os.path.join(this_dir, 'configs', '%s.json' % configuration_name)
+    assert os.path.exists(cfg_path), \
+        'Requested unknown configuration {}'.format(configuration_name)
+
+    # Load config file and deserialize it.
+    with open(cfg_path, 'r') as f:
+        data = json.load(f)
+    cfg = DetectionConfig.deserialize(data)
+
+    return cfg

--- a/python-sdk/nuscenes/eval/detection/evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate.py
@@ -17,6 +17,7 @@ from nuscenes.eval.detection.constants import TP_METRICS
 from nuscenes.eval.detection.data_classes import DetectionConfig, MetricDataList, DetectionMetrics, EvalBoxes
 from nuscenes.eval.detection.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
 from nuscenes.eval.detection.render import summary_plot, class_pr_curve, class_tp_curve, dist_pr_curve, visualize_sample
+from nuscenes.eval.detection.config import config_factory
 
 
 class NuScenesEval:
@@ -267,12 +268,10 @@ if __name__ == "__main__":
     verbose_ = bool(args.verbose)
 
     if config_path == '':
-        this_dir = os.path.dirname(os.path.abspath(__file__))
-        cfg_name = 'cvpr_2019.json'
-        config_path = os.path.join(this_dir, 'configs', cfg_name)
-
-    with open(config_path, 'r') as f:
-        cfg_ = DetectionConfig.deserialize(json.load(f))
+        cfg_ = config_factory('cvpr_2019')
+    else:
+        with open(config_path, 'r') as f:
+            cfg_ = DetectionConfig.deserialize(json.load(f))
 
     nusc_ = NuScenes(version=version_, verbose=verbose_, dataroot=dataroot_)
     nusc_eval = NuScenesEval(nusc_, config=cfg_, result_path=result_path_, eval_set=eval_set_,

--- a/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from nuscenes import NuScenes
 from nuscenes.eval.detection import NuScenesEval
-from nuscenes.eval.detection.data_classes import DetectionConfig
+from nuscenes.eval.detection.config import config_factory
 from nuscenes.eval.detection.utils import category_to_detection_name, detection_name_to_rel_attributes
 from nuscenes.utils.splits import create_splits_scenes
 
@@ -112,12 +112,7 @@ class TestMain(unittest.TestCase):
         with open(self.res_mockup, 'w') as f:
             json.dump(self._mock_submission(nusc, 'mini_val'), f, indent=2)
 
-        this_dir = os.path.dirname(os.path.abspath(__file__))
-        cfg_name = 'cvpr_2019.json'
-        cfg_path = os.path.join(this_dir, '..', 'configs', cfg_name)
-        with open(cfg_path, 'r') as f:
-            cfg = DetectionConfig.deserialize(json.load(f))
-
+        cfg = config_factory('cvpr_2019')
         nusc_eval = NuScenesEval(nusc, cfg, self.res_mockup, eval_set='mini_val', output_dir=self.res_eval_folder,
                                  verbose=False)
         metrics, md_list = nusc_eval.evaluate()


### PR DESCRIPTION
This PR revives the config factory for greater convenience when a user wants to use a provided config (e.g. cvpr_2019). Previously the user would need to figure out the location of the config file.