### PR TITLE
nuScenes KITTI 2d boxes

### DIFF
--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -3,7 +3,12 @@
 # Licensed under the Creative Commons [see license.txt]
 
 """
-Export 2D annotations (xmin, ymin,xmax, ymax) from re-projections of our annotated 3D bounding boxes to a .json file.
+Export 2D annotations (xmin, ymin, xmax, ymax) from re-projections of our annotated 3D bounding boxes to a .json file.
+
+Note: Projecting tight 3d boxes to 2d generally leads to non-tight boxes.
+      Furthermore it is non-trivial to determine whether a box falls into the image, rather than behind or around it.
+      Finally some of the objects may be occluded by other objects, in particular when the lidar can see them, but the
+      cameras cannot.
 """
 
 from nuscenes.nuscenes import NuScenes
@@ -138,7 +143,7 @@ def get_2d_boxes(sample_data_token: str, visibilities: List[str]) -> List[Ordere
         in_front = np.argwhere(corners_3d[2, :] > 0).flatten()
         corners_3d = corners_3d[:, in_front]
 
-        # Applying the re-projection algorithm post-processing step..
+        # Applying the re-projection algorithm post-processing step.
         corner_coords = view_points(corners_3d, camera_intrinsic, True).T[:, :2].tolist()
         final_coords = post_process_coords(corner_coords)
 

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -28,6 +28,7 @@ This script includes three main functions:
 To launch these scripts run:
 - python export_kitti.py nuscenes_gt_to_kitti --nusc_kitti_dir ~/nusc_kitti
 - python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti
+- python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti --render_2d True
 - python export_kitti.py kitti_res_to_nuscenes --nusc_kitti_dir ~/nusc_kitti
 
 To work with the original KITTI dataset, use these parameters:
@@ -251,6 +252,11 @@ class KittiConverter:
         Renders the annotations in the KITTI dataset from a lidar and a camera view.
         :param render_2d: Whether to render 2d boxes (only works for camera data).
         """
+        if render_2d:
+            print('Rendering 2d boxes from KITTI format')
+        else:
+            print('Rendering 3d boxes projected from 3d KITTI format')
+
         # Load the KITTI dataset.
         kitti = KittiDB(root=self.nusc_kitti_dir, splits=(self.split,))
 

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -227,11 +227,19 @@ class KittiConverter:
                     if detection_name is None:
                         continue
 
-                    # Convert to KITTI 3d and 2d box and KITTI output format.
+                    # Set dummy score so we can use this file as result.
+                    box_cam_kitti.score = 0
+
+                    # Convert from nuScenes to KITTI box format.
                     box_cam_kitti = KittiDB.box_nuscenes_to_kitti(
                         box_lidar_nusc, Quaternion(matrix=velo_to_cam_rot), velo_to_cam_trans, r0_rect)
-                    box_cam_kitti.score = 0  # Set dummy score so we can use this file as result.
+
+                    # Project 3d box to 2d box in image, ignore box if it does not fall inside.
                     bbox_2d = KittiDB.project_kitti_box_to_image(box_cam_kitti, p_left_kitti, imsize=imsize)
+                    if bbox_2d is None:
+                        continue
+
+                    # Convert box to output string format.
                     output = KittiDB.box_to_string(name=detection_name, box=box_cam_kitti, bbox_2d=bbox_2d,
                                                    truncation=truncated, occlusion=occluded)
 

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -90,6 +90,7 @@ class KittiConverter:
         """
         kitti_to_nu_lidar = Quaternion(axis=(0, 0, 1), angle=np.pi / 2)
         kitti_to_nu_lidar_inv = kitti_to_nu_lidar.inverse
+        imsize = (1600, 900)
 
         token_idx = 0  # Start tokens from 0.
 
@@ -230,8 +231,9 @@ class KittiConverter:
                     box_cam_kitti = KittiDB.box_nuscenes_to_kitti(
                         box_lidar_nusc, Quaternion(matrix=velo_to_cam_rot), velo_to_cam_trans, r0_rect)
                     box_cam_kitti.score = 0  # Set dummy score so we can use this file as result.
-                    output = KittiDB.box_to_string(name=detection_name, box=box_cam_kitti, truncation=truncated,
-                                                   occlusion=occluded)
+                    bbox_2d = KittiDB.project_kitti_box_to_image(box_cam_kitti, p_left_kitti, imsize=imsize)
+                    output = KittiDB.box_to_string(name=detection_name, box=box_cam_kitti, bbox_2d=bbox_2d,
+                                                   truncation=truncated, occlusion=occluded)
 
                     # Write to disk.
                     label_file.write(output + '\n')

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -27,9 +27,9 @@ This script includes three main functions:
 
 To launch these scripts run:
 - python export_kitti.py nuscenes_gt_to_kitti --nusc_kitti_dir ~/nusc_kitti
-- python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti
-- python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti --render_2d True
+- python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti --render_2d False
 - python export_kitti.py kitti_res_to_nuscenes --nusc_kitti_dir ~/nusc_kitti
+Note: The parameter --render_2d specifies whether to draw 2d or 3d boxes.
 
 To work with the original KITTI dataset, use these parameters:
  --nusc_kitti_dir /data/sets/kitti --split training

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -227,9 +227,6 @@ class KittiConverter:
                     if detection_name is None:
                         continue
 
-                    # Set dummy score so we can use this file as result.
-                    box_cam_kitti.score = 0
-
                     # Convert from nuScenes to KITTI box format.
                     box_cam_kitti = KittiDB.box_nuscenes_to_kitti(
                         box_lidar_nusc, Quaternion(matrix=velo_to_cam_rot), velo_to_cam_trans, r0_rect)
@@ -238,6 +235,9 @@ class KittiConverter:
                     bbox_2d = KittiDB.project_kitti_box_to_image(box_cam_kitti, p_left_kitti, imsize=imsize)
                     if bbox_2d is None:
                         continue
+
+                    # Set dummy score so we can use this file as result.
+                    box_cam_kitti.score = 0
 
                     # Convert box to output string format.
                     output = KittiDB.box_to_string(name=detection_name, box=box_cam_kitti, bbox_2d=bbox_2d,

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -246,9 +246,10 @@ class KittiConverter:
                     # Write to disk.
                     label_file.write(output + '\n')
 
-    def render_kitti(self) -> None:
+    def render_kitti(self, render_2d: bool) -> None:
         """
         Renders the annotations in the KITTI dataset from a lidar and a camera view.
+        :param render_2d: Whether to render 2d boxes (only works for camera data).
         """
         # Load the KITTI dataset.
         kitti = KittiDB(root=self.nusc_kitti_dir, splits=(self.split,))
@@ -263,7 +264,7 @@ class KittiConverter:
             for sensor in ['lidar', 'camera']:
                 out_path = os.path.join(render_dir, '%s_%s.png' % (token, sensor))
                 print('Rendering file to disk: %s' % out_path)
-                kitti.render_sample_data(token, sensor_modality=sensor, out_path=out_path)
+                kitti.render_sample_data(token, sensor_modality=sensor, out_path=out_path, render_2d=render_2d)
                 plt.close()  # Close the windows to avoid a warning of too many open windows.
 
     def kitti_res_to_nuscenes(self, meta: Dict[str, bool] = None) -> None:

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -217,7 +217,7 @@ class KittiConverter:
                     # Truncated: Set all objects to 0 which means untruncated.
                     truncated = 0.0
 
-                    # Occluded: Hard-coded: Full visibility.
+                    # Occluded: Set all objects to full visibility as this information is not available in nuScenes.
                     occluded = 0
 
                     # Convert nuScenes category to nuScenes detection challenge category.

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -182,6 +182,7 @@ class KittiDB:
         # Crop bbox to prevent it extending outside image
         bbox_crop = (max(0, bbox[0]), max(0, bbox[1]), min(imsize[0], bbox[2]), min(imsize[1], bbox[3]))
 
+        assert bbox_crop[0] < bbox_crop[2] and bbox_crop[1] < bbox_crop[3], 'Error: Box conversion error!'
         return bbox_crop
 
     @staticmethod
@@ -362,13 +363,13 @@ class KittiDB:
 
         # Prepare output.
         name += ' '
-        trunc = '{:.3f} '.format(truncation)
+        trunc = '{:.2f} '.format(truncation)
         occ = '{:d} '.format(occlusion)
-        a = '{:.3f} '.format(alpha)
-        bb = '{:.3f} {:.3f} {:.3f} {:.3f} '.format(bbox_2d[0], bbox_2d[1], bbox_2d[2], bbox_2d[3])
-        hwl = '{:.3f} {:.3f} {:.3f} '.format(box.wlh[2], box.wlh[0], box.wlh[1])  # height, width, length.
-        xyz = '{:.3f} {:.3f} {:.3f} '.format(box.center[0], box.center[1], box.center[2])  # x, y, z.
-        y = '{:.3f}'.format(yaw)  # Yaw angle.
+        a = '{:.2f} '.format(alpha)
+        bb = '{:.2f} {:.2f} {:.2f} {:.2f} '.format(bbox_2d[0], bbox_2d[1], bbox_2d[2], bbox_2d[3])
+        hwl = '{:.2} {:.2f} {:.2f} '.format(box.wlh[2], box.wlh[0], box.wlh[1])  # height, width, length.
+        xyz = '{:.2f} {:.2f} {:.2f} '.format(box.center[0], box.center[1], box.center[2])  # x, y, z.
+        y = '{:.2f}'.format(yaw)  # Yaw angle.
         s = ' {:.4f}'.format(box.score)  # Classification score.
 
         output = name + trunc + occ + a + bb + hwl + xyz + y

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -336,7 +336,7 @@ class KittiDB:
     @staticmethod
     def box_to_string(name: str,
                       box: Box,
-                      bbox: Tuple[float, float, float, float] = (-1.0, -1.0, -1.0, -1.0),
+                      bbox_2d: Tuple[float, float, float, float] = (-1.0, -1.0, -1.0, -1.0),
                       truncation: float = -1.0,
                       occlusion: int = -1,
                       alpha: float = -10.0) -> str:
@@ -344,7 +344,8 @@ class KittiDB:
         Convert box in KITTI image frame to official label string fromat.
         :param name: KITTI name of the box.
         :param box: Box class in KITTI image frame.
-        :param bbox: Optional, 2D bounding box obtained by projected Box into image. Otherwise set to KITTI default.
+        :param bbox_2d: Optional, 2D bounding box obtained by projected Box into image (xmin, ymin, xmax, ymax).
+            Otherwise set to KITTI default.
         :param truncation: Optional truncation, otherwise set to KITTI default.
         :param occlusion: Optional occlusion, otherwise set to KITTI default.
         :param alpha: Optional alpha, otherwise set to KITTI default.
@@ -359,7 +360,7 @@ class KittiDB:
         trunc = '{:.3f} '.format(truncation)
         occ = '{:d} '.format(occlusion)
         a = '{:.3f} '.format(alpha)
-        bb = '{:.3f} {:.3f} {:.3f} {:.3f} '.format(bbox[0], bbox[1], bbox[2], bbox[3])  # bbox (xmin, ymin, xmax, ymax).
+        bb = '{:.3f} {:.3f} {:.3f} {:.3f} '.format(bbox_2d[0], bbox_2d[1], bbox_2d[2], bbox_2d[3])
         hwl = '{:.3f} {:.3f} {:.3f} '.format(box.wlh[2], box.wlh[0], box.wlh[1])  # height, width, length.
         xyz = '{:.3f} {:.3f} {:.3f} '.format(box.center[0], box.center[1], box.center[2])  # x, y, z.
         y = '{:.3f}'.format(yaw)  # Yaw angle.

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -170,8 +170,12 @@ class KittiDB:
         # We use the true center, so we need to adjust half height in negative y direction.
         box.translate(np.array([0, -box.wlh[2] / 2, 0]))
 
-        # Project corners that are in front of the camera to 2d to get bbox in pixel coords.
+        # Check that some corners are inside the image.
         corners = np.array([corner for corner in box.corners().T if corner[2] > 0]).T
+        if len(corners) == 0:
+            return None
+
+        # Project corners that are in front of the camera to 2d to get bbox in pixel coords.
         imcorners = view_points(corners, p_left, normalize=True)[:2]
         bbox = (np.min(imcorners[0]), np.min(imcorners[1]), np.max(imcorners[0]), np.max(imcorners[1]))
 

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -4,7 +4,7 @@
 
 import os
 from os import path as osp
-from typing import List, Tuple, Any, Optional
+from typing import List, Tuple, Any, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -154,7 +154,7 @@ class KittiDB:
 
     @staticmethod
     def project_kitti_box_to_image(box: Box, p_left: np.ndarray, imsize: Tuple[int, int]) \
-            -> Optional[None, Tuple[int, int, int, int]]:
+            -> Union[None, Tuple[int, int, int, int]]:
         """
         Projects 3D box into KITTI image FOV.
         :param box: 3D box in KITTI reference frame.

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -179,10 +179,17 @@ class KittiDB:
         imcorners = view_points(corners, p_left, normalize=True)[:2]
         bbox = (np.min(imcorners[0]), np.min(imcorners[1]), np.max(imcorners[0]), np.max(imcorners[1]))
 
-        # Crop bbox to prevent it extending outside image
-        bbox_crop = (max(0, bbox[0]), max(0, bbox[1]), min(imsize[0], bbox[2]), min(imsize[1], bbox[3]))
+        # Crop bbox to prevent it extending outside image.
+        bbox_crop = tuple(max(0, b) for b in bbox)
+        bbox_crop = (min(imsize[0], bbox_crop[0]),
+                     min(imsize[0], bbox_crop[1]),
+                     min(imsize[0], bbox_crop[2]),
+                     min(imsize[1], bbox_crop[3]))
 
-        assert bbox_crop[0] < bbox_crop[2] and bbox_crop[1] < bbox_crop[3], 'Error: Box conversion error!'
+        # Detect if a cropped box is empty.
+        if bbox_crop[0] >= bbox_crop[2] or bbox_crop[1] >= bbox_crop[3]:
+            return None
+
         return bbox_crop
 
     @staticmethod

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -4,7 +4,7 @@
 
 import os
 from os import path as osp
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -153,13 +153,14 @@ class KittiDB:
         return box
 
     @staticmethod
-    def project_kitti_box_to_image(box: Box, p_left: np.ndarray, imsize: Tuple[int, int]) -> Tuple[int, int, int, int]:
+    def project_kitti_box_to_image(box: Box, p_left: np.ndarray, imsize: Tuple[int, int]) \
+            -> Optional[None, Tuple[int, int, int, int]]:
         """
         Projects 3D box into KITTI image FOV.
         :param box: 3D box in KITTI reference frame.
         :param p_left: <np.float: 3, 4>. Projection matrix.
         :param imsize: (width, height). Image size.
-        :return: (xmin, ymin, xmax, ymax). Bounding box in image plane.
+        :return: (xmin, ymin, xmax, ymax). Bounding box in image plane or None if box is not in the image.
         """
 
         # Create a new box.
@@ -170,7 +171,7 @@ class KittiDB:
         box.translate(np.array([0, -box.wlh[2] / 2, 0]))
 
         # Project corners that are in front of the camera to 2d to get bbox in pixel coords.
-        corners = np.array([corner for corner in box.corners().T if -corner[2] > 0]).T
+        corners = np.array([corner for corner in box.corners().T if corner[2] > 0]).T
         imcorners = view_points(corners, p_left, normalize=True)[:2]
         bbox = (np.min(imcorners[0]), np.min(imcorners[1]), np.max(imcorners[0]), np.max(imcorners[1]))
 

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -158,7 +158,7 @@ class KittiDB:
         Projects 3D box into KITTI image FOV.
         :param box: 3D box in KITTI reference frame.
         :param p_left: <np.float: 3, 4>. Projection matrix.
-        :param imsize: (width , height). Image size.
+        :param imsize: (width, height). Image size.
         :return: (xmin, ymin, xmax, ymax). Bounding box in image plane.
         """
 
@@ -169,8 +169,8 @@ class KittiDB:
         # We use the true center, so we need to adjust half height in negative y direction.
         box.translate(np.array([0, -box.wlh[2] / 2, 0]))
 
-        # Project corners to 2d to get bbox in pixel coords.
-        corners = np.array([corner for corner in box.corners().T if corner[2] > 0]).T
+        # Project corners that are in front of the camera to 2d to get bbox in pixel coords.
+        corners = np.array([corner for corner in box.corners().T if -corner[2] > 0]).T
         imcorners = view_points(corners, p_left, normalize=True)[:2]
         bbox = (np.min(imcorners[0]), np.min(imcorners[1]), np.max(imcorners[0]), np.max(imcorners[1]))
 


### PR DESCRIPTION
This PR addresses https://github.com/nutonomy/nuscenes-devkit/issues/156 by adding 2d boxes to the KITTI output. It also enables rendering the 2d annotatons:
```
python export_kitti.py render_kitti --nusc_kitti_dir ~/nusc_kitti --render_2d False
```
Furthermore we add a disclaimer to the 3d-2d conversion script that the resulting boxes are generally not tight.

Below are some example of 2d and 3d boxes:
![mini_train_356d81f38dd9473ba590f39e266f54e5_camera](https://user-images.githubusercontent.com/39502217/58008511-236c1800-7b1f-11e9-9b8a-c04f38366a2f.png)
![mini_train_356d81f38dd9473ba590f39e266f54e5_camera](https://user-images.githubusercontent.com/39502217/58008522-26670880-7b1f-11e9-99e2-1c1ceb20160c.png)