### PR TITLE
Print per class metrics after evaluation

### DIFF
--- a/python-sdk/nuscenes/eval/detection/evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate.py
@@ -229,6 +229,21 @@ class NuScenesEval:
         print('NDS: %.4f' % (metrics_summary['nd_score']))
         print('Eval time: %.1fs' % metrics_summary['eval_time'])
 
+        # Print per-class metrics.
+        print()
+        print('Per-class results:')
+        print('Object Class\tAP\tATE\tASE\tAOE\tAVE\tAAE')
+        class_aps = metrics_summary['mean_dist_aps']
+        class_tps = metrics_summary['label_tp_errors']
+        for class_name in class_aps.keys():
+            print('%s\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f'
+                  % (class_name, class_aps[class_name],
+                     class_tps[class_name]['trans_err'],
+                     class_tps[class_name]['scale_err'],
+                     class_tps[class_name]['orient_err'],
+                     class_tps[class_name]['vel_err'],
+                     class_tps[class_name]['attr_err']))
+
         return metrics_summary
 
 


### PR DESCRIPTION
Currently, teams that submit to the nuScenes evaluation server can only see metrics averaged over classes. This PR prints the per-class metrics to stdout so users can get immediate feedback.