### PR TITLE
Pointcloud projection issue workaround

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -512,12 +512,16 @@ class NuScenesExplorer:
             ann_record = self.nusc.get('sample_annotation', ann_token)
             print('sample_annotation_token: {}, category: {}'.format(ann_record['token'], ann_record['category_name']))
 
-    def map_pointcloud_to_image(self, pointsensor_token: str, camera_token: str) -> Tuple:
+    def map_pointcloud_to_image(self,
+                                pointsensor_token: str,
+                                camera_token: str,
+                                min_dist: float = 1.0) -> Tuple:
         """
         Given a point sensor (lidar/radar) token and camera sample_data token, load point-cloud and map it to the image
         plane.
         :param pointsensor_token: Lidar/radar sample_data token.
         :param camera_token: Camera sample_data token.
+        :param min_dist: Distance from the camera below which points are discarded.
         :return (pointcloud <np.float: 2, n)>, coloring <np.float: n>, image <Image>).
         """
 
@@ -562,10 +566,10 @@ class NuScenesExplorer:
         points = view_points(pc.points[:3, :], np.array(cs_record['camera_intrinsic']), normalize=True)
 
         # Remove points that are either outside or behind the camera. Leave a margin of 1 pixel for aesthetic reasons.
-        # Also make sure points are at least 10cm in front of the camera to avoid seeing the lidar points on the camera
+        # Also make sure points are at least 1m in front of the camera to avoid seeing the lidar points on the camera
         # casing for non-keyframes which are slightly out of sync.
         mask = np.ones(depths.shape[0], dtype=bool)
-        mask = np.logical_and(mask, depths > 0.1)
+        mask = np.logical_and(mask, depths > min_dist)
         mask = np.logical_and(mask, points[0, :] > 1)
         mask = np.logical_and(mask, points[0, :] < im.size[0] - 1)
         mask = np.logical_and(mask, points[1, :] > 1)

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -562,8 +562,10 @@ class NuScenesExplorer:
         points = view_points(pc.points[:3, :], np.array(cs_record['camera_intrinsic']), normalize=True)
 
         # Remove points that are either outside or behind the camera. Leave a margin of 1 pixel for aesthetic reasons.
+        # Also make sure points are at least 10cm in front of the camera to avoid seeing the lidar points on the camera
+        # casing for non-keyframes which are slightly out of sync.
         mask = np.ones(depths.shape[0], dtype=bool)
-        mask = np.logical_and(mask, depths > 0)
+        mask = np.logical_and(mask, depths > 0.1)
         mask = np.logical_and(mask, points[0, :] > 1)
         mask = np.logical_and(mask, points[0, :] < im.size[0] - 1)
         mask = np.logical_and(mask, points[1, :] > 1)

--- a/schema.md
+++ b/schema.md
@@ -88,10 +88,12 @@ ego_pose
 ---------
 
 Ego vehicle pose at a particular timestamp. Given with respect to global coordinate system of the log's map.
+The ego_pose is the output of a lidar map-based localization algorithm described in our paper.
+The localization is 2-dimensional in the x-y plane.
 ```
 ego_pose {
    "token":                   <str> -- Unique record identifier.
-   "translation":             <float> [3] -- Coordinate system origin in meters: x, y, z.
+   "translation":             <float> [3] -- Coordinate system origin in meters: x, y, z. Note that z is always 0.
    "rotation":                <float> [4] -- Coordinate system orientation as quaternion: w, x, y, z.
    "timestamp":               <int> -- Unix time stamp.
 }


### PR DESCRIPTION
This PR alleviates #175 by filtering points with a distance below 10cm. However, it does not resolve the underlying issue if one tries to render pointclouds in the camera that are out of sync.

Furthermore, I added some clarifications that the provided ego_pose has no meaningful z component.