### PR TITLE
Project map to image, resolves #188

### DIFF
--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -640,7 +640,7 @@ class NuScenesMapExplorer:
         """
         # TODO
         alpha = 0.5
-        patch_radius = 50
+        patch_radius = 100
 
         # Check that NuScenesMap was loaded for the correct location.
         sample_record = nusc.get('sample', sample_token)
@@ -668,8 +668,7 @@ class NuScenesMapExplorer:
         records_in_patch = self.get_records_in_patch(box_coords, layer_names, 'intersect')
 
         # Init axes.
-        fig = plt.figure(figsize=(9, 16))
-        ax = fig.add_axes([0, 0, 1, 1])  # TODO: adjust aspect ratio
+        _, ax = plt.subplots(1, 1, figsize=(9, 16))
         ax.imshow(im)
 
         # Retrieve and render each record.

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -259,7 +259,9 @@ class NuScenesMap:
         :param out_path: Optional path to save the rendered figure to disk.
         """
         self.explorer.render_map_in_image(nusc, sample_token, camera_channel=camera_channel, alpha=alpha,
-                                          patch_radius=patch_radius, layer_names=layer_names, out_path=out_path)
+                                          patch_radius=patch_radius, min_polygon_area=min_polygon_area,
+                                          render_behind_cam=render_behind_cam, render_outside_im=render_outside_im,
+                                          layer_names=layer_names, out_path=out_path)
 
     def render_map_mask(self,
                         patch_box: Tuple[float, float, float, float],

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -791,9 +791,18 @@ class NuScenesMapExplorer:
             plt.tight_layout()
             plt.savefig(out_path, bbox_inches='tight', pad_inches=0)
 
-    def _clip_points_behind_camera(self, points, near_plane):
-        # Perform clipping on polygons that are partially behind the camera.
-
+    def _clip_points_behind_camera(self, points, near_plane: float):
+        """
+        Perform clipping on polygons that are partially behind the camera.
+        This method is necessary as the projection does not work for points behind the camera.
+        Hence we compute the line between the point and the camera and follow that line until we hit the near plane of
+        the camera. Then we use that point.
+        :param points: <np.float32: 3, n> Matrix of points, where each point (x, y, z) is along each column.
+        :param near_plane: If we set the near_plane distance of the camera to 0 then some points will project to
+            infinity. Therefore we need to clip these points at the near plane.
+        :return: The clipped version of the polygon. This may have fewer points than the original polygon if some lines
+            were entirely behind the polygon.
+        """
         points_clipped = []
         # Loop through each line on the polygon.
         # For each line where exactly 1 endpoints is behind the camera, move the point along the line until

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -31,7 +31,7 @@ plt.style.use('seaborn-whitegrid')
 
 class NuScenesMap:
     """
-    MapGraph database class for querying and retrieving information from the semantic maps.
+    NuScenesMap database class for querying and retrieving information from the semantic maps.
     Before using this class please use the provided tutorial in `map_demo.ipynb`.
 
     Below you can find the map origins (south eastern corner, in [lat, lon]) for each of the 4 maps in nuScenes:
@@ -194,7 +194,7 @@ class NuScenesMap:
                       figsize: Tuple[int, int] = (15, 15),
                       other_layers: List[str] = None) -> Tuple[Figure, Tuple[Axes, Axes]]:
         """
-         Render a single map graph record. By default will also render 3 layers which are `drivable_area`, `lane`,
+         Render a single map record. By default will also render 3 layers which are `drivable_area`, `lane`,
          and `walkway` unless specified by `other_layers`.
          :param layer_name: Name of the layer that we are interested in.
          :param token: Token of the record that you want to render.
@@ -246,6 +246,7 @@ class NuScenesMap:
                             out_path: str = None) -> None:
         """
         Render a nuScenes camera image and overlay the polygons for the specified map layers.
+        Note that the projections are not always accurate as the localization is in 2d.
         :param nusc: The NuScenes instance to load the image from.
         :param sample_token: The image's corresponding sample_token.
         :param camera_channel: Camera channel name, e.g. 'CAM_FRONT'.
@@ -380,7 +381,7 @@ class NuScenesMapExplorer:
                  representative_layers: Tuple[str] = ('drivable_area', 'lane', 'walkway'),
                  color_map: dict = None):
         """
-        :param map_api: MapGraph database class.
+        :param map_api: NuScenesMap database class.
         :param representative_layers: These are the layers that we feel are representative of the whole mapping data.
         :param color_map: Color map.
         """
@@ -510,7 +511,7 @@ class NuScenesMapExplorer:
                       figsize: Tuple[int, int] = (15, 15),
                       other_layers: List[str] = None) -> Tuple[Figure, Tuple[Axes, Axes]]:
         """
-        Render a single map graph record.
+        Render a single map record.
         By default will also render 3 layers which are `drivable_area`, `lane`, and `walkway` unless specified by
         `other_layers`.
         :param layer_name: Name of the layer that we are interested in.
@@ -657,6 +658,7 @@ class NuScenesMapExplorer:
                             out_path: str = None) -> None:
         """
         Render a nuScenes camera image and overlay the polygons for the specified map layers.
+        Note that the projections are not always accurate as the localization is in 2d.
         :param nusc: The NuScenes instance to load the image from.
         :param sample_token: The image's corresponding sample_token.
         :param camera_channel: Camera channel name, e.g. 'CAM_FRONT'.
@@ -670,6 +672,8 @@ class NuScenesMapExplorer:
         :param out_path: Optional path to save the rendered figure to disk.
         """
         near_plane = 1e-8
+
+        print('Warning: Note that the projections are not always accurate as the localization is in 2d.')
 
         # Default layers.
         if layer_names is None:
@@ -727,7 +731,7 @@ class NuScenesMapExplorer:
                 for polygon_token in polygon_tokens:
                     polygon = self.map_api.extract_polygon(polygon_token)
 
-                    # Prepare pointcloud and set height to camera height.
+                    # Convert polygon nodes to pointcloud with 0 height.
                     points = np.array(polygon.exterior.xy)
                     points = np.vstack((points, np.zeros((1, points.shape[1]))))
 

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -749,9 +749,12 @@ class NuScenesMapExplorer:
                     if np.all(behind):
                         continue
 
-                    # Perform clipping on polygons that are partially behind the camera.
                     if render_behind_cam:
+                        # Perform clipping on polygons that are partially behind the camera.
                         points = self._clip_points_behind_camera(points, near_plane)
+                    elif np.any(behind):
+                        # Otherwise ignore any polygon that is partially behind the camera.
+                        continue
 
                     # Ignore polygons with less than 3 points after clipping.
                     if len(points) == 0 or points.shape[1] < 3:

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -668,24 +668,30 @@ class NuScenesMapExplorer:
         records_in_patch = self.get_records_in_patch(box_coords, layer_names, 'intersect')
 
         # Init axes.
-        _, ax = plt.subplots(1, 1, figsize=(9, 16))
-        ax.imshow(im)
+        fig = plt.figure(figsize=(9, 16))
+        ax = fig.add_axes([0, 0, 2000, 2000 / self.canvas_aspect_ratio]) # TODO
+        #ax.imshow(im)
 
         # Retrieve and render each record.
         for layer_name in layer_names:
-            first_time = True
             assert layer_name != 'drivable_area'
             for token in records_in_patch[layer_name]:
                 record = self.map_api.get(layer_name, token)
                 polygon = self.map_api.extract_polygon(record['polygon_token'])
 
-                if first_time:
-                    label = layer_name
-                    first_time = False
-                else:
-                    label = None
+                # Project points to image view.
+                points = np.array(polygon.exterior.xy)
+                points = points #/ points.max()
+                points = [(p0, p1) for (p0, p1) in zip(points[0], points[1])]
+                polygon_proj = Polygon(points)
 
-                ax.add_patch(descartes.PolygonPatch(polygon, fc=self.color_map[layer_name], alpha=alpha, label=label))
+                # Debug: Test triangle
+                #polygon_proj = Polygon([(0, 0), (1, 0), (0, 1)], [])
+
+                # TODO: check first_Time
+
+                label = layer_name
+                ax.add_patch(descartes.PolygonPatch(polygon_proj, fc=self.color_map[layer_name], alpha=alpha, label=label))
 
         # Display the image.
         plt.axis('off')

--- a/python-sdk/nuscenes/map_expansion/map_demo.ipynb
+++ b/python-sdk/nuscenes/map_expansion/map_demo.ipynb
@@ -170,6 +170,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Rendering map layers on top of camera images\n",
+    "Let us take a nuScenes camera image and overlay the relevant map layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nuscenes.map_expansion.map_api import NuScenesMap\n",
+    "from nuscenes.nuscenes import NuScenes\n",
+    "\n",
+    "nusc = NuScenes(version='v1.0-mini', verbose=False)\n",
+    "nusc_map = NuScenesMap(map_name='singapore-onenorth')\n",
+    "\n",
+    "sample_token = nusc.sample[0]['token']\n",
+    "nusc_map.render_map_in_image(nusc, sample_token, out_path='test.jpg')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Data Exploration"
    ]
   },

--- a/python-sdk/nuscenes/map_expansion/map_demo.ipynb
+++ b/python-sdk/nuscenes/map_expansion/map_demo.ipynb
@@ -171,7 +171,8 @@
    "metadata": {},
    "source": [
     "### Rendering map layers on top of camera images\n",
-    "Let us take a nuScenes camera image and overlay the relevant map layers."
+    "Let us take a nuScenes camera image and overlay the relevant map layers.\n",
+    "Note that the projections are not perfect if the ground is uneven as the localization is 2d."
    ]
   },
   {
@@ -180,24 +181,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nuscenes.map_expansion.map_api import NuScenesMap\n",
+    "# Init nuScenes. Requires the dataset to be stored on disk.\n",
     "from nuscenes.nuscenes import NuScenes\n",
-    "\n",
     "nusc = NuScenes(version='v1.0-mini', verbose=False)\n",
-    "nusc_map = NuScenesMap(map_name='singapore-onenorth')\n",
     "\n",
-    "sample_token = nusc.sample[0]['token']\n",
-    "nusc_map.render_map_in_image(nusc, sample_token, out_path='test.jpg')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "plt.show()"
+    "# Pick a sample and render the front camera image.\n",
+    "sample_token = nusc.sample[9]['token']\n",
+    "layer_names = ['road_segment', 'lane', 'ped_crossing', 'walkway', 'stop_line', 'carpark_area']\n",
+    "camera_channel = 'CAM_FRONT'\n",
+    "nusc_map.render_map_in_image(nusc, sample_token, layer_names=layer_names, camera_channel=camera_channel)"
    ]
   },
   {

--- a/python-sdk/nuscenes/map_expansion/map_demo.ipynb
+++ b/python-sdk/nuscenes/map_expansion/map_demo.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is the tutorial for the nuScenes map expansion. In particular, the `NuscenesMap` data class. \n",
+    "This is the tutorial for the nuScenes map expansion. In particular, the `NuScenesMap` data class. \n",
     "\n",
     "This tutorial will go through the description of each layers, how we retrieve and query a certain record within the map layers, render methods, and advanced data exploration\n",
     "\n",
@@ -32,7 +32,7 @@
    "source": [
     "### Initialization\n",
     "\n",
-    "We will be working with the `singapore-onenorth` map. The `NuscenesMap` can be initialized as follows:"
+    "We will be working with the `singapore-onenorth` map. The `NuScenesMap` can be initialized as follows:"
    ]
   },
   {
@@ -42,9 +42,9 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from nuscenes.map_expansion.map_api import NuscenesMap\n",
+    "from nuscenes.map_expansion.map_api import NuScenesMap\n",
     "\n",
-    "nusc_map = NuscenesMap(dataroot='/data/sets/nuscenes', map_name='singapore-onenorth')"
+    "nusc_map = NuScenesMap(dataroot='/data/sets/nuscenes', map_name='singapore-onenorth')"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "source": [
     "### Rendering multiple layers\n",
     "\n",
-    "The `NuscenesMap` class makes it possible to render multiple map layers on a matplotlib figure."
+    "The `NuScenesMap` class makes it possible to render multiple map layers on a matplotlib figure."
    ]
   },
   {
@@ -116,7 +116,7 @@
    "source": [
     "### Rendering binary map mask layers\n",
     "\n",
-    "The `NuscenesMap` class makes it possible to convert multiple map layers into binary mask and render on a Matplotlib figure. First let's call `get_map_mask` to look at the raw data of two layers:"
+    "The `NuScenesMap` class makes it possible to convert multiple map layers into binary mask and render on a Matplotlib figure. First let's call `get_map_mask` to look at the raw data of two layers:"
    ]
   },
   {

--- a/python-sdk/nuscenes/utils/geometry_utils.py
+++ b/python-sdk/nuscenes/utils/geometry_utils.py
@@ -44,7 +44,7 @@ def view_points(points: np.ndarray, view: np.ndarray, normalize: bool) -> np.nda
 
     nbr_points = points.shape[1]
 
-    # Do operation in homogenous coordinates
+    # Do operation in homogenous coordinates.
     points = np.concatenate((points, np.ones((1, nbr_points))))
     points = np.dot(viewpad, points)
     points = points[:3, :]

--- a/python-sdk/tutorial.ipynb
+++ b/python-sdk/tutorial.ipynb
@@ -751,7 +751,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This also has a `token` field (they all do). In addition, it has several fields of the format [a-z]*\\_token, _e.g._ instance_token. These are foreign keys in database speak, meaning they point to another table. \n",
+    "This also has a `token` field (they all do). In addition, it has several fields of the format [a-z]*\\_token, _e.g._ instance_token. These are foreign keys in database terminology, meaning they point to another table. \n",
     "Using `nusc.get()` we can grab any of these in constant time. For example, let's look at the visibility record."
    ]
   },


### PR DESCRIPTION
This PR addresses the previously requested feature to project semantic map layers into the camera image view. The main difficulty here is to figure out what to do with polygons where some points are behind the camera. Note that the projections are not always accurate as the localization is in 2d.

An example was added to the tutorial.
![map-tutorial](https://user-images.githubusercontent.com/39502217/61942385-dfd4d500-afcb-11e9-960e-18688452ba45.png)


A video with some renderings can be found at: https://www.youtube.com/watch?v=wUBdMrnL6BU&feature=youtu.be