### PR TITLE
render_annotation improved

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -822,9 +822,8 @@ class NuScenesExplorer:
         :param view: LIDAR view point.
         :param box_vis_level: If sample_data is an image, this sets required visibility for boxes.
         :param out_path: Optional path to save the rendered figure to disk.
-        :param extra_info: whether or not to render extra information below CAMERA view
+        :param extra_info: Whether to render extra information below camera view.
         """
-
         ann_record = self.nusc.get('sample_annotation', anntoken)
         sample_record = self.nusc.get('sample', ann_record['sample_token'])
         assert 'LIDAR_TOP' in sample_record['data'].keys(), 'No LIDAR_TOP in data, cant render'
@@ -868,8 +867,8 @@ class NuScenesExplorer:
             c = np.array(self.get_color(box.name)) / 255.0
             box.render(axes[1], view=camera_intrinsic, normalize=True, colors=(c, c, c))
 
+        # Print extra information about the annotation below the camera view.
         if extra_info:
-            # print extra information about the annotation below the CAMERA view
             rcParams['font.family'] = 'monospace'
 
             w, l, h = ann_record['size']
@@ -911,7 +910,7 @@ class NuScenesExplorer:
         :param view: LIDAR view point.
         :param box_vis_level: If sample_data is an image, this sets required visibility for boxes.
         :param out_path: Optional path to save the rendered figure to disk.
-        :param extra_info: whether or not to render extra information below CAMERA view
+        :param extra_info: Whether to render extra information below camera view.
         """
         ann_tokens = self.nusc.field2token('sample_annotation', 'instance_token', instance_token)
         closest = [np.inf, None]


### PR DESCRIPTION
I added optional rendering of extra information about the annotation below the CAMERA view.

[example image](https://i.ibb.co/nPRp96D/9cba9cd8af85487fb010652c90d845b5-1538448747047643.png)

I set the default value four times to `False`:
[here](https://github.com/MartinHahner88/nuscenes-devkit-fork/blob/f51d5d1316ebf7cd9249107da7a1f5fbd3d0e70c/python-sdk/nuscenes/nuscenes.py#L403), [here](https://github.com/MartinHahner88/nuscenes-devkit-fork/blob/f51d5d1316ebf7cd9249107da7a1f5fbd3d0e70c/python-sdk/nuscenes/nuscenes.py#L408), [here](https://github.com/MartinHahner88/nuscenes-devkit-fork/blob/f51d5d1316ebf7cd9249107da7a1f5fbd3d0e70c/python-sdk/nuscenes/nuscenes.py#L817) and [ here](https://github.com/MartinHahner88/nuscenes-devkit-fork/blob/f51d5d1316ebf7cd9249107da7a1f5fbd3d0e70c/python-sdk/nuscenes/nuscenes.py#L906)

Feel free to change it to `True` if you prefer that.