### PR TITLE
Lyft compatibility default settings

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -400,8 +400,8 @@ class NuScenes:
 
     def render_sample_data(self, sample_data_token: str, with_anns: bool = True,
                            box_vis_level: BoxVisibility = BoxVisibility.ANY, axes_limit: float = 40, ax: Axes = None,
-                           nsweeps: int = 1, out_path: str = None, underlay_map: bool = False,
-                           use_flat_vehicle_coordinates: bool = False) -> None:
+                           nsweeps: int = 1, out_path: str = None, underlay_map: bool = True,
+                           use_flat_vehicle_coordinates: bool = True) -> None:
         self.explorer.render_sample_data(sample_data_token, with_anns, box_vis_level, axes_limit, ax, nsweeps=nsweeps,
                                          out_path=out_path, underlay_map=underlay_map,
                                          use_flat_vehicle_coordinates=use_flat_vehicle_coordinates)
@@ -676,13 +676,15 @@ class NuScenesExplorer:
     def render_ego_centric_map(self,
                                sample_data_token: str,
                                axes_limit: float = 40,
-                               rotate_lidar: bool = False,
+                               ego_to_lidar: bool = False,
                                ax: Axes = None) -> None:
         """
         Render map centered around the associated ego pose.
+        Warning: This method is not exact when using `ego_to_lidar`, as the lidar coordinate frame is not perfectly
+                 aligned with the vertical axis when going up a slope.
         :param sample_data_token: Sample_data token.
         :param axes_limit: Axes limit measured in meters.
-        :param rotate_lidar: Whether to approximately rotate the map from ego to the lidar frame (0 ~ up).
+        :param ego_to_lidar: Whether to approximately rotate the map from ego to the lidar frame (0 ~ up).
         :param ax: Axes onto which to render.
         """
 
@@ -717,7 +719,7 @@ class NuScenesExplorer:
         # Rotate image.
         ypr_rad = Quaternion(pose['rotation']).yaw_pitch_roll
         yaw_deg = -math.degrees(ypr_rad[0])
-        if rotate_lidar:
+        if ego_to_lidar:
             # Note that this is an approximation. The rotation between ego and lidar frame is not exactly 90 degrees.
             yaw_deg += 90
         rotated_cropped = np.array(Image.fromarray(cropped).rotate(yaw_deg))
@@ -744,8 +746,8 @@ class NuScenesExplorer:
                            ax: Axes = None,
                            nsweeps: int = 1,
                            out_path: str = None,
-                           underlay_map: bool = False,
-                           use_flat_vehicle_coordinates: bool = False) -> None:
+                           underlay_map: bool = True,
+                           use_flat_vehicle_coordinates: bool = True) -> None:
         """
         Render sample data onto axis.
         :param sample_data_token: Sample_data token.

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -760,7 +760,7 @@ class NuScenesExplorer:
         :param underlay_map: When set to true, LIDAR data is plotted onto the map. This can be slow.
         :param use_flat_vehicle_coordinates: Instead of the current sensor's coordinate frame, use ego frame which is
             aligned to z-plane in the world.
-            Note: Previously this method did not use flat vehicle coordinates which can lead to small errors when the
+            Note: Previously this method did not use flat vehicle coordinates, which can lead to small errors when the
                   vertical axis of the global frame and lidar are not aligned. The new setting is more correct and
                   rotates the plot by ~90 degrees.
         """

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -759,8 +759,10 @@ class NuScenesExplorer:
         :param out_path: Optional path to save the rendered figure to disk.
         :param underlay_map: When set to true, LIDAR data is plotted onto the map. This can be slow.
         :param use_flat_vehicle_coordinates: Instead of the current sensor's coordinate frame, use ego frame which is
-                                             aligned to z-plane in the world.
-                                             Warning: Enabling this will rotate the plot by ~90 degrees.
+            aligned to z-plane in the world.
+            Note: Previously this method did not use flat vehicle coordinates which can lead to small errors when the
+                  vertical axis of the global frame and lidar are not aligned. The new setting is more correct and
+                  rotates the plot by ~90 degrees.
         """
         # Get sensor modality.
         sd_record = self.nusc.get('sample_data', sample_data_token)
@@ -819,7 +821,7 @@ class NuScenesExplorer:
             # Render map if requested.
             if underlay_map:
                 self.render_ego_centric_map(sample_data_token=sample_data_token, axes_limit=axes_limit,
-                                            rotate_lidar=not use_flat_vehicle_coordinates, ax=ax)
+                                            ego_to_lidar=not use_flat_vehicle_coordinates, ax=ax)
 
             # Show point cloud.
             points = view_points(pc.points[:3, :], viewpoint, normalize=False)


### PR DESCRIPTION
This PR changes the default settings for render_sample_data to use underlay_map and use_flat_vehicle_coordinates by default. It also prevents the user from attempting to underlay the map in the lidar view, which is not correct when the lidar vertical axis is not aligned with the global vertical axis.