### PR TITLE
Add option to render pointcloud intensities

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -579,6 +579,7 @@ class NuScenesExplorer:
         depths = pc.points[2, :]
 
         if render_intensity:
+            assert pointsensor['sensor_modality'] == 'lidar', 'Error: Can only render intensity for lidar!'
             # Retrieve the color from the intensities.
             # Performs arbitary scaling to achieve more visually pleasing results.
             intensities = pc.points[3, :]

--- a/python-sdk/tutorial.ipynb
+++ b/python-sdk/tutorial.ipynb
@@ -1082,6 +1082,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "In the previous image the colors indicate the distance from the ego vehicle to each lidar point. We can also render the lidar intensity. In the following image the traffic sign ahead of us is highly reflective (yellow) and the dark vehicle on the right has low reflectivity (purple)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nusc.render_pointcloud_in_image(my_sample['token'], pointsensor_channel='LIDAR_TOP', render_intensity=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Second, let's plot the radar point cloud for the same image. Radar is less dense than lidar, but has a much larger range."
    ]
   },


### PR DESCRIPTION
This PR adds an option to `render_pointcloud_in_image` to visualize the lidar intensities.
This only works for lidar, not for radar.