### PR TITLE
Made tracking unit-tests silent and executed by default

### DIFF
--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -104,7 +104,7 @@ def load_gt(nusc: NuScenes, eval_split: str, box_cls, verbose: bool = False) -> 
 
     # Load annotations and filter predictions and annotations.
     tracking_id_set = set()
-    for sample_token in tqdm.tqdm(sample_tokens):
+    for sample_token in tqdm.tqdm(sample_tokens, leave=verbose):
 
         sample = nusc.get('sample', sample_token)
         sample_annotation_tokens = sample['anns']

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -75,7 +75,8 @@ class TrackingEvaluation(object):
         :returns: TrackingMetricData instance which holds the metrics for each threshold.
         """
         # Init.
-        print('Computing metrics for class %s...\n' % self.class_name)
+        if self.verbose:
+            print('Computing metrics for class %s...\n' % self.class_name)
         accumulators = []
         thresh_metrics = []
         md = TrackingMetricData()
@@ -123,7 +124,8 @@ class TrackingEvaluation(object):
             thresh_metrics.append(thresh_summary)
 
             # Print metrics to stdout.
-            print_threshold_metrics(thresh_summary.to_dict())
+            if self.verbose:
+                print_threshold_metrics(thresh_summary.to_dict())
 
         # Concatenate all metrics. We only do this for more convenient access.
         summary = pandas.concat(thresh_metrics)

--- a/python-sdk/nuscenes/eval/tracking/evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/evaluate.py
@@ -93,8 +93,8 @@ class TrackingEval:
         self.sample_tokens = gt_boxes.sample_tokens
 
         # Convert boxes to tracks format.
-        self.tracks_gt = create_tracks(gt_boxes, nusc, self.eval_set, gt=True)
-        self.tracks_pred = create_tracks(pred_boxes, nusc, self.eval_set, gt=False)
+        self.tracks_gt = create_tracks(gt_boxes, nusc, self.eval_set, gt=True, verbose=verbose)
+        self.tracks_pred = create_tracks(pred_boxes, nusc, self.eval_set, gt=False, verbose=verbose)
 
     def evaluate(self) -> Tuple[TrackingMetrics, TrackingMetricDataList]:
         """
@@ -199,7 +199,8 @@ class TrackingEval:
             json.dump(metric_data_list.serialize(), f, indent=2)
 
         # Print metrics to stdout.
-        print_final_metrics(metrics)
+        if self.verbose:
+            print_final_metrics(metrics)
 
         # Render curves.
         if render_curves:

--- a/python-sdk/nuscenes/eval/tracking/loaders.py
+++ b/python-sdk/nuscenes/eval/tracking/loaders.py
@@ -1,5 +1,6 @@
 from bisect import bisect
 from typing import List, Dict
+from collections import defaultdict
 
 import numpy as np
 from pyquaternion import Quaternion
@@ -57,13 +58,10 @@ def interpolate_tracks(tracks_by_timestamp: Dict[int, List[TrackingBox]]) -> Dic
     :return: The interpolated tracks.
     """
     # Group tracks by id.
-    tracks_by_id = {}
-    track_timestamps_by_id = {}
+    tracks_by_id = defaultdict(list)
+    track_timestamps_by_id = defaultdict(list)
     for timestamp, tracking_boxes in tracks_by_timestamp.items():
         for tracking_box in tracking_boxes:
-            if tracking_box.tracking_id not in tracks_by_id.keys():
-                tracks_by_id[tracking_box.tracking_id] = []
-                track_timestamps_by_id[tracking_box.tracking_id] = []
             tracks_by_id[tracking_box.tracking_id].append(tracking_box)
             track_timestamps_by_id[tracking_box.tracking_id].append(timestamp)
 
@@ -113,27 +111,8 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
         if scene['name'] in splits[eval_split]:
             scene_tokens.add(scene_token)
 
-    # Init all scenes and timestamps to guarantee completeness.
-    tracks = {}
-    for scene_token in scene_tokens:
-        # Init scene.
-        if scene_token not in tracks:
-            tracks[scene_token] = {}
-
-        # Init all timestamps in this scene.
-        scene = nusc.get('scene', scene_token)
-        cur_sample_token = scene['first_sample_token']
-        while True:
-            # Initialize array for current timestamp.
-            cur_sample = nusc.get('sample', cur_sample_token)
-            tracks[scene_token][cur_sample['timestamp']] = []
-
-            # Abort after the last sample.
-            if cur_sample_token == scene['last_sample_token']:
-                break
-
-            # Move to next sample.
-            cur_sample_token = cur_sample['next']
+    # Tracks is stored as dict {scene_token: {timestamp: List[TrackingBox]}}.
+    tracks = defaultdict(lambda: defaultdict(list))
 
     # Group annotations wrt scene and timestamp.
     for sample_token in all_boxes.sample_tokens:
@@ -143,12 +122,9 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
 
     # Interpolate GT and predicted tracks.
     for scene_token in tracks.keys():
-        tracks[scene_token] = interpolate_tracks(tracks[scene_token])
-
-    # Make sure the tracks are sorted in time.
-    # This is always the case for GT, but may not be the case for predictions.
-    if not gt:
-        for scene_token in tracks.keys():
+        interpolate_tracks(tracks[scene_token])
+        if not gt:
+            # Make sure predictions are sorted in in time. (Always true for GT).
             tracks[scene_token] = dict(sorted(tracks[scene_token].items(), key=lambda kv: kv[0]))
 
     return tracks

--- a/python-sdk/nuscenes/eval/tracking/loaders.py
+++ b/python-sdk/nuscenes/eval/tracking/loaders.py
@@ -115,8 +115,25 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
         if scene['name'] in splits[eval_split]:
             scene_tokens.add(scene_token)
 
-    # Tracks is stored as dict {scene_token: {timestamp: List[TrackingBox]}}.
+    # Tracks are stored as dict {scene_token: {timestamp: List[TrackingBox]}}.
     tracks = defaultdict(lambda: defaultdict(list))
+
+    # Init all scenes and timestamps to guarantee completeness.
+    for scene_token in scene_tokens:
+        # Init all timestamps in this scene.
+        scene = nusc.get('scene', scene_token)
+        cur_sample_token = scene['first_sample_token']
+        while True:
+            # Initialize array for current timestamp.
+            cur_sample = nusc.get('sample', cur_sample_token)
+            tracks[scene_token][cur_sample['timestamp']] = []
+
+            # Abort after the last sample.
+            if cur_sample_token == scene['last_sample_token']:
+                break
+
+            # Move to next sample.
+            cur_sample_token = cur_sample['next']
 
     # Group annotations wrt scene and timestamp.
     for sample_token in all_boxes.sample_tokens:
@@ -126,9 +143,10 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
 
     # Interpolate GT and predicted tracks.
     for scene_token in tracks.keys():
-        interpolate_tracks(tracks[scene_token], verbose=verbose)
+        tracks[scene_token] = interpolate_tracks(tracks[scene_token], verbose=verbose)
+
         if not gt:
             # Make sure predictions are sorted in in time. (Always true for GT).
-            tracks[scene_token] = dict(sorted(tracks[scene_token].items(), key=lambda kv: kv[0]))
+            tracks[scene_token] = defaultdict(list, sorted(tracks[scene_token].items(), key=lambda kv: kv[0]))
 
     return tracks

--- a/python-sdk/nuscenes/eval/tracking/loaders.py
+++ b/python-sdk/nuscenes/eval/tracking/loaders.py
@@ -49,12 +49,14 @@ def interpolate_tracking_boxes(left_box: TrackingBox, right_box: TrackingBox, ri
                        tracking_score=tracking_score)
 
 
-def interpolate_tracks(tracks_by_timestamp: Dict[int, List[TrackingBox]]) -> Dict[int, List[TrackingBox]]:
+def interpolate_tracks(tracks_by_timestamp: Dict[int, List[TrackingBox]], verbose: bool = False) -> \
+        Dict[int, List[TrackingBox]]:
     """
     Interpolate the tracks to fill in holes, especially since GT boxes with 0 lidar points are removed.
     We are rediscovering an information that already exists in nuscenes.
     This interpolation does not take into account visibility. It interpolates despite occlusion.
     :param tracks_by_timestamp: The tracks.
+    :param verbose: Whether to print verbose outputs to stdout.
     :return: The interpolated tracks.
     """
     # Group tracks by id.
@@ -86,12 +88,13 @@ def interpolate_tracks(tracks_by_timestamp: Dict[int, List[TrackingBox]]) -> Dic
                 tracking_box = interpolate_tracking_boxes(left_tracking_box, right_tracking_box, right_ratio)
                 interpolate_count += 1
                 tracks_by_timestamp[timestamp].append(tracking_box)
-    print('Interpolated %d boxes' % interpolate_count)
+    if verbose:
+        print('Interpolated %d boxes' % interpolate_count)
 
     return tracks_by_timestamp
 
 
-def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: bool)\
+def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: bool, verbose: bool)\
         -> Dict[str, Dict[int, List[TrackingBox]]]:
     """
     Returns all tracks for all scenes. Samples within a track are sorted in chronological order.
@@ -100,6 +103,7 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
     :param nusc: The NuScenes instance to load the sample information from.
     :param eval_split: The evaluation split for which we create tracks.
     :param gt: Whether we are creating tracks for GT or predictions
+    :param verbose: Whether to print verbose outputs to stdout.
     :return: The tracks.
     """
     # Only keep samples from this split.
@@ -122,7 +126,7 @@ def create_tracks(all_boxes: EvalBoxes, nusc: NuScenes, eval_split: str, gt: boo
 
     # Interpolate GT and predicted tracks.
     for scene_token in tracks.keys():
-        interpolate_tracks(tracks[scene_token])
+        interpolate_tracks(tracks[scene_token], verbose=verbose)
         if not gt:
             # Make sure predictions are sorted in in time. (Always true for GT).
             tracks[scene_token] = dict(sorted(tracks[scene_token].items(), key=lambda kv: kv[0]))

--- a/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
@@ -182,9 +182,4 @@ class TestAlgo(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    algo = TestAlgo()
-    algo.test_perfect_gt()
-    algo.test_drop_prediction()
-    algo.test_identity_switch()
-    algo.test_drop_gt()
-    algo.test_drop_gt_interpolate()
+    unittest.main()

--- a/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
@@ -83,7 +83,7 @@ class TestMain(unittest.TestCase):
 
         # Prepare results.
         instance_to_score = dict()
-        for sample in tqdm(val_samples):
+        for sample in tqdm(val_samples, leave=False):
             sample_res = []
             for ann_token in sample['anns']:
                 ann = nusc.get('sample_annotation', ann_token)

--- a/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
@@ -164,7 +164,7 @@ class TestMain(unittest.TestCase):
 
         cfg = config_factory('tracking_nips_2019')
         nusc_eval = TrackingEval(nusc, cfg, self.res_mockup, eval_set=eval_set, output_dir=self.res_eval_folder,
-                                 verbose=True)
+                                 verbose=False)
         metrics = nusc_eval.main(render_curves=render_curves)
 
         return metrics
@@ -224,5 +224,4 @@ class TestMain(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    TestMain().test_delta_gt(render_curves=False)
-    TestMain().test_delta_mock(render_curves=False)
+    unittest.main()

--- a/python-sdk/nuscenes/eval/tracking/utils.py
+++ b/python-sdk/nuscenes/eval/tracking/utils.py
@@ -2,6 +2,7 @@
 # Code written by Holger Caesar, 2019.
 
 from typing import Optional, Dict
+import warnings
 
 import numpy as np
 import motmetrics
@@ -136,6 +137,9 @@ def create_motmetrics() -> MetricsHost:
     # Create new metrics host object.
     mh = MetricsHost()
 
+    # Suppress deprecation warning from py-motmetrics.
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
     # Register standard metrics.
     fields = [
         'num_frames', 'obj_frequencies', 'num_matches', 'num_switches', 'num_false_positives', 'num_misses',
@@ -144,6 +148,9 @@ def create_motmetrics() -> MetricsHost:
     ]
     for field in fields:
         mh.register(getattr(motmetrics.metrics, field), formatter='{:d}'.format)
+
+    # Reenable deprecation warning.
+    warnings.filterwarnings('default', category=DeprecationWarning)
 
     # Register custom metrics.
     # Specify all inputs to avoid errors incompatibility between type hints and py-motmetric's introspection.


### PR DESCRIPTION
This PR has 3 proposed cosmetic changes related to unit-tests:
- Made sure all tests run non-verbose. 
- Added `__init__.py` to tests folder to make sure it's indexed by `python -m unittest`. 
- Made it so that all tests run by default, not just the ones enumerated explicitly.
