### PR TITLE
Pandas minimum version requirement

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 motmetrics
 numpy
 opencv-python
+pandas>=0.24
 Pillow
 pyquaternion>=0.9.5
 scikit-learn


### PR DESCRIPTION
In the following line we use Pandas with the `codes` keyword.
https://github.com/nutonomy/nuscenes-devkit/blob/d60d7b1caf9b336f11d036a2787194f387238407/python-sdk/nuscenes/eval/tracking/mot.py#L44 

This keyword was introduced in `v0.24`, while `py-motmetrics` only requires `v0.23`. Therefore this PR adds an explicit requirement on version `>=v0.24`.
