### PR TITLE
Adding PredictHelper class and unit tests

### DIFF
--- a/python-sdk/nuscenes/predict/__init__.py
+++ b/python-sdk/nuscenes/predict/__init__.py
@@ -1,0 +1,1 @@
+from .helper import PredictHelper, convert_global_coords_to_local

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -1,3 +1,5 @@
+# nuScenes dev-kit.
+# Code written by Freddy Boulton, 2020.
 
 from typing import Dict, Tuple, Any, List, Callable
 from pyquaternion import Quaternion
@@ -138,6 +140,7 @@ class PredictHelper:
 
     def _get_past_or_future_for_sample(self, sample: str, seconds: float, in_agent_frame: bool,
                                       function: Callable[[str, str, float, bool], np.ndarray]):
+        """Helper function to reduce code duplication between get_future and get_past for sample."""
         sample_record = self.data.get('sample', sample)
         sequences = {}
         for annotation in sample_record['anns']:

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -189,7 +189,7 @@ class PredictHelper:
                                                   in_agent_frame, direction='prev')
 
     def _get_past_or_future_for_sample(self, sample_token: str, seconds: float, in_agent_frame: bool,
-                                       function: Callable[[str, str, float, bool], np.ndarray]):
+                                       function: Callable[[str, str, float, bool], np.ndarray]) -> Dict[str, np.ndarray]:
         """
         Helper function to reduce code duplication between get_future and get_past for sample.
         :param sample_token: Sample token.

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -1,0 +1,176 @@
+
+from typing import Dict, Tuple, Any, List
+from pyquaternion import Quaternion
+from nuscenes import NuScenes
+from nuscenes.utils.geometry_utils import transform_matrix
+from nuscenes.eval.common.utils import quaternion_yaw
+import numpy as np
+
+MICROSECONDS_PER_SECOND = 1e6
+BUFFER = 0.15 # seconds
+
+def angle_of_rotation(yaw: float) -> float:
+    return (np.pi / 2) + np.sign(-yaw) * np.abs(yaw)
+
+def convert_global_coords_to_local(coordinates: np.ndarray,
+                                   translation: Tuple[float, float, float],
+                                   rotation: Tuple[float, float, float, float]) -> np.ndarray:
+
+    yaw = angle_of_rotation(quaternion_yaw(Quaternion(rotation)))
+
+    transform = np.array([[np.cos(yaw), -np.sin(yaw)], [np.sin(yaw), np.cos(yaw)]])
+
+    coords = (coordinates - np.atleast_2d(np.array(translation)[:2])).T
+
+    return np.dot(transform, coords).T[:, :2]
+
+class PredictHelper:
+    """Wrapper class around NuScenes to help retrieve data for the prediction task."""
+
+    def __init__(self, nusc: NuScenes):
+        """Inits PredictHelper
+        :param nusc: Instance of NuScenes class
+        """
+        self.data = nusc
+        self.inst_sample_to_ann = self._map_sample_and_instance_to_annotation()
+
+    def _map_sample_and_instance_to_annotation(self) -> Dict[Tuple[str, str], str]:
+        """Creates mapping to look up an annotation given a sample and instance in constant time."""
+        mapping = {}
+
+        for record in self.data.sample_annotation:
+            mapping[(record['sample_token'], record['instance_token'])] = record['token']
+
+        return mapping
+
+    def _timestamp_for_sample(self, sample: str):
+        """"""
+        return self.data.get('sample', sample)['timestamp']
+
+    def _absolute_time_diff(self, time1: int, time2: int) -> int:
+        """Helper to compute how much time has elapsed in _iterate method."""
+        return abs(time1 - time2) / MICROSECONDS_PER_SECOND
+
+    def _iterate(self, starting_annotation: Dict[str, Any], seconds: float, direction: str) -> List[Dict[str, Any]]:
+        """Iterates forwards or backwards in time through the annotations for a given amount of seconds."""
+
+        seconds_with_buffer = seconds + BUFFER
+        starting_time = self._timestamp_for_sample(starting_annotation['sample_token'])
+
+        next_annotation = starting_annotation
+
+        time_elapsed = 0
+
+        annotations = []
+
+        while time_elapsed <= seconds_with_buffer:
+
+            if next_annotation[direction] == '':
+                break
+
+            next_annotation = self.data.get('sample_annotation', next_annotation[direction])
+            current_time = self._timestamp_for_sample(next_annotation['sample_token'])
+
+            time_elapsed = self._absolute_time_diff(current_time, starting_time)
+
+            if time_elapsed < seconds_with_buffer:
+                annotations.append(next_annotation)
+
+        return annotations
+
+    def get_sample_annotation(self, instance: str, sample: str) -> Dict[str, Any]:
+        """Retrives an annotation given an instance token and its sample.
+        :param instance: Instance token
+        :param sample: Sample token
+        """
+        return self.data.get('sample_annotation', self.inst_sample_to_ann[(sample, instance)])
+
+    def get_future_for_agent(self, instance: str, sample: str,
+                             seconds: float, in_agent_frame: bool) -> np.array:
+        """Retrieves the agent's future x,y locations.
+        :param instance: Instance token
+        :param sample: Sample token
+        :param seconds: How much future data to retrieve
+        :in_agent_frame: If true, locations are rotated to the agent frame.
+        :return: np.ndarray. First column is the x coordinate, second is the y.
+            The rows increase with time, i.e the last row occurs the farthest from
+            the current time.
+        """
+        starting_annotation = self.get_sample_annotation(instance, sample)
+        future = self._iterate(starting_annotation, seconds, 'next')
+        coords = np.array([r['translation'][:2] for r in future])
+
+        if in_agent_frame:
+            coords = convert_global_coords_to_local(coords,
+                                                    starting_annotation['translation'],
+                                                    starting_annotation['rotation'])
+
+        return coords
+
+    def get_past_for_agent(self, instance: str, sample: str,
+                           seconds: float, in_agent_frame: bool) -> np.array:
+        """Retrieves the agent's past x,y locations
+        :param instance: Instance token
+        :param sample: Sample token
+        :param seconds: How much past data to retrieve
+        :in_agent_frame: If true, locations are rotated to the agent frame.
+        :return: np.ndarray. First column is the x coordinate, second is the y.
+            The rows decreate with time, i.e the last row happened the farthest from
+            the current time.
+        """
+        starting_annotation = self.get_sample_annotation(instance, sample)
+        past = self._iterate(starting_annotation, seconds, 'prev')
+        coords = np.array([r['translation'][:2] for r in past])
+
+        if in_agent_frame:
+            coords = convert_global_coords_to_local(coords,
+                                                    starting_annotation['translation'],
+                                                    starting_annotation['rotation'])
+
+        return coords
+
+    def get_future_for_sample(self, sample: str, seconds: float, in_agent_frame: bool) -> Dict[str, np.ndarray]:
+        """Retrieves the the future x,y locations of all agents in the sample.
+        :param instance: Instance token
+        :param sample: Sample token
+        :param seconds: How much future data to retrieve
+        :in_agent_frame: If true, locations are rotated to the agent frame.
+        :return: np.ndarray. First column is the x coordinate, second is the y.
+            The rows increase with time, i.e the last row occurs the farthest from
+            the current time.
+        """
+        sample_record = self.data.get('sample', sample)
+        futures = {}
+        for annotation in sample_record['anns']:
+            annotation_record = self.data.get('sample_annotation', annotation)
+            future = self.get_future_for_agent(annotation_record['instance_token'],
+                                               annotation_record['sample_token'],
+                                               seconds, in_agent_frame)
+
+            futures[annotation_record['instance_token']] = future
+
+        return futures
+
+    def get_past_for_sample(self, sample: str, seconds: float, in_agent_frame: bool) -> Dict[str, np.ndarray]:
+        """Retrieves the the past x,y locations of all agents in the sample.
+        :param instance: Instance token
+        :param sample: Sample token
+        :param seconds: How much past data to retrieve
+        :in_agent_frame: If true, locations are rotated to the agent frame.
+        :return: np.ndarray. First column is the x coordinate, second is the y.
+            The rows increase with time, i.e the last row occurs the farthest from
+            the current time.
+        """
+        sample_record = self.data.get('sample', sample)
+        pasts = {}
+        for annotation in sample_record['anns']:
+            annotation_record = self.data.get('sample_annotation', annotation)
+            past = self.get_past_for_agent(annotation_record['instance_token'],
+                                               annotation_record['sample_token'],
+                                               seconds, in_agent_frame)
+
+            pasts[annotation_record['instance_token']] = past
+
+        return pasts
+
+

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -2,8 +2,9 @@
 # Code written by Freddy Boulton, 2020.
 
 from typing import Dict, Tuple, Any, List, Callable
-from pyquaternion import Quaternion
+
 import numpy as np
+from pyquaternion import Quaternion
 
 from nuscenes import NuScenes
 from nuscenes.eval.common.utils import quaternion_yaw
@@ -33,7 +34,6 @@ def convert_global_coords_to_local(coordinates: np.ndarray,
         Representation - cos(theta / 2) + (xi + yi + zi)sin(theta / 2).
     :return: TODO.
     """
-
     yaw = angle_of_rotation(quaternion_yaw(Quaternion(rotation)))
 
     transform = np.array([[np.cos(yaw), -np.sin(yaw)], [np.sin(yaw), np.cos(yaw)]])
@@ -91,7 +91,6 @@ class PredictHelper:
         :param direction: TODO.
         :return: TODO.
         """
-
         if seconds < 0:
             raise ValueError(f"Parameter seconds must be non-negative. Recevied {seconds}.")
 

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -1,5 +1,5 @@
 
-from typing import Dict, Tuple, Any, List
+from typing import Dict, Tuple, Any, List, Callable
 from pyquaternion import Quaternion
 from nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import transform_matrix
@@ -10,16 +10,19 @@ MICROSECONDS_PER_SECOND = 1e6
 BUFFER = 0.15 # seconds
 
 def angle_of_rotation(yaw: float) -> float:
+    """Given a yaw (measured from x axis) find the angle needed to rotate by so that
+    the yaw points upwards (pi / 2)."""
     return (np.pi / 2) + np.sign(-yaw) * np.abs(yaw)
 
 def convert_global_coords_to_local(coordinates: np.ndarray,
                                    translation: Tuple[float, float, float],
                                    rotation: Tuple[float, float, float, float]) -> np.ndarray:
     """Converts global coordinates to coordinates in the frame given by the rotation quaternion and
-    centered at the translation vector.
+    centered at the translation vector. The rotation is meant to be a z-axis rotation.
     :param coordinates: x,y locations. array of shape [n_steps, 2]
     :param translation: Tuple of (x, y, z) location that is the center of the new frame
-    :param rotation: Tuple representation of quaternion of new frame."""
+    :param rotation: Tuple representation of quaternion of new frame.
+        Representation - cos(theta / 2) + (xi + yi + zi)sin(theta / 2)."""
 
     yaw = angle_of_rotation(quaternion_yaw(Quaternion(rotation)))
 
@@ -90,6 +93,21 @@ class PredictHelper:
         """
         return self.data.get('sample_annotation', self.inst_sample_to_ann[(sample, instance)])
 
+    def _get_past_or_future_for_agent(self, instance: str, sample: str,
+                                       seconds: float, in_agent_frame: bool,
+                                       direction: str) -> np.ndarray:
+        """Helper function to reduce code duplication between get_future and get_past for agent."""
+        starting_annotation = self.get_sample_annotation(instance, sample)
+        sequence = self._iterate(starting_annotation, seconds, direction)
+        coords = np.array([r['translation'][:2] for r in sequence])
+
+        if in_agent_frame:
+            coords = convert_global_coords_to_local(coords,
+                                                    starting_annotation['translation'],
+                                                    starting_annotation['rotation'])
+
+        return coords
+
     def get_future_for_agent(self, instance: str, sample: str,
                              seconds: float, in_agent_frame: bool) -> np.array:
         """Retrieves the agent's future x,y locations.
@@ -101,16 +119,8 @@ class PredictHelper:
             The rows increase with time, i.e the last row occurs the farthest from
             the current time.
         """
-        starting_annotation = self.get_sample_annotation(instance, sample)
-        future = self._iterate(starting_annotation, seconds, 'next')
-        coords = np.array([r['translation'][:2] for r in future])
-
-        if in_agent_frame:
-            coords = convert_global_coords_to_local(coords,
-                                                    starting_annotation['translation'],
-                                                    starting_annotation['rotation'])
-
-        return coords
+        return self._get_past_or_future_for_agent(instance, sample, seconds,
+                                                  in_agent_frame, direction='next')
 
     def get_past_for_agent(self, instance: str, sample: str,
                            seconds: float, in_agent_frame: bool) -> np.array:
@@ -123,16 +133,23 @@ class PredictHelper:
             The rows decreate with time, i.e the last row happened the farthest from
             the current time.
         """
-        starting_annotation = self.get_sample_annotation(instance, sample)
-        past = self._iterate(starting_annotation, seconds, 'prev')
-        coords = np.array([r['translation'][:2] for r in past])
+        return self._get_past_or_future_for_agent(instance, sample, seconds,
+                                                  in_agent_frame, direction='prev')
 
-        if in_agent_frame:
-            coords = convert_global_coords_to_local(coords,
-                                                    starting_annotation['translation'],
-                                                    starting_annotation['rotation'])
+    def _get_past_or_future_for_sample(self, sample: str, seconds: float, in_agent_frame: bool,
+                                      function: Callable[[str, str, float, bool], np.ndarray]):
+        sample_record = self.data.get('sample', sample)
+        sequences = {}
+        for annotation in sample_record['anns']:
+            annotation_record = self.data.get('sample_annotation', annotation)
+            sequence = function(annotation_record['instance_token'],
+                                annotation_record['sample_token'],
+                                seconds, in_agent_frame)
 
-        return coords
+            sequences[annotation_record['instance_token']] = sequence
+
+        return sequences
+
 
     def get_future_for_sample(self, sample: str, seconds: float, in_agent_frame: bool) -> Dict[str, np.ndarray]:
         """Retrieves the the future x,y locations of all agents in the sample.
@@ -144,17 +161,9 @@ class PredictHelper:
             The rows increase with time, i.e the last row occurs the farthest from
             the current time.
         """
-        sample_record = self.data.get('sample', sample)
-        futures = {}
-        for annotation in sample_record['anns']:
-            annotation_record = self.data.get('sample_annotation', annotation)
-            future = self.get_future_for_agent(annotation_record['instance_token'],
-                                               annotation_record['sample_token'],
-                                               seconds, in_agent_frame)
+        return self._get_past_or_future_for_sample(sample, seconds, in_agent_frame,
+                                                   function=self.get_future_for_agent)
 
-            futures[annotation_record['instance_token']] = future
-
-        return futures
 
     def get_past_for_sample(self, sample: str, seconds: float, in_agent_frame: bool) -> Dict[str, np.ndarray]:
         """Retrieves the the past x,y locations of all agents in the sample.
@@ -166,16 +175,7 @@ class PredictHelper:
             The rows increase with time, i.e the last row occurs the farthest from
             the current time.
         """
-        sample_record = self.data.get('sample', sample)
-        pasts = {}
-        for annotation in sample_record['anns']:
-            annotation_record = self.data.get('sample_annotation', annotation)
-            past = self.get_past_for_agent(annotation_record['instance_token'],
-                                               annotation_record['sample_token'],
-                                               seconds, in_agent_frame)
-
-            pasts[annotation_record['instance_token']] = past
-
-        return pasts
+        return self._get_past_or_future_for_sample(sample, seconds, in_agent_frame,
+                                                   function=self.get_past_for_agent)
 
 

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -53,8 +53,8 @@ class PredictHelper:
 
         return mapping
 
-    def _timestamp_for_sample(self, sample: str):
-        """"""
+    def _timestamp_for_sample(self, sample: str) -> float:
+        """Gets timestamp from sample token."""
         return self.data.get('sample', sample)['timestamp']
 
     def _absolute_time_diff(self, time1: int, time2: int) -> int:

--- a/python-sdk/nuscenes/predict/helper.py
+++ b/python-sdk/nuscenes/predict/helper.py
@@ -15,6 +15,11 @@ def angle_of_rotation(yaw: float) -> float:
 def convert_global_coords_to_local(coordinates: np.ndarray,
                                    translation: Tuple[float, float, float],
                                    rotation: Tuple[float, float, float, float]) -> np.ndarray:
+    """Converts global coordinates to coordinates in the frame given by the rotation quaternion and
+    centered at the translation vector.
+    :param coordinates: x,y locations. array of shape [n_steps, 2]
+    :param translation: Tuple of (x, y, z) location that is the center of the new frame
+    :param rotation: Tuple representation of quaternion of new frame."""
 
     yaw = angle_of_rotation(quaternion_yaw(Quaternion(rotation)))
 

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -1,3 +1,6 @@
+# nuScenes dev-kit.
+# Code written by Freddy Boulton, 2020.
+
 import unittest
 from typing import Dict, List, Any
 from nuscenes.predict import PredictHelper, convert_global_coords_to_local

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -3,13 +3,18 @@
 
 import unittest
 from typing import Dict, List, Any
-from nuscenes.predict import PredictHelper, convert_global_coords_to_local
+
 import numpy as np
 
-class MockNuScenes:
-    """Mocks the NuScenes API needed to test PredictHelper"""
+from nuscenes.nuscenes import NuScenes
+from nuscenes.predict import PredictHelper, convert_global_coords_to_local
 
-    def __init__(self, sample_annotations: List[Dict[str, Any]],
+
+class MockNuScenes(NuScenes):
+    """ Mocks the NuScenes API needed to test PredictHelper. """
+
+    def __init__(self,
+                 sample_annotations: List[Dict[str, Any]],
                  samples: List[Dict[str, Any]]):
 
         self._sample_annotation = {r['token']: r for r in sample_annotations}
@@ -23,7 +28,8 @@ class MockNuScenes:
         assert table_name in {'sample_annotation', 'sample'}
         return getattr(self, "_" + table_name)[token]
 
-class Test_convert_global_coords_to_local(unittest.TestCase):
+
+class TestConvertGlobalCoordsToLocal(unittest.TestCase):
 
     def setUp(self):
         along_pos_x = np.zeros((5, 2))
@@ -246,32 +252,47 @@ class TestPredictHelper(unittest.TestCase):
 
     def setUp(self):
 
-        self.mock_annotations = [{'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0], 'rotation': [1, 0, 0, 0],
-                                  'prev': '', 'next': '2'},
-                                 {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1], 'prev': '1', 'next': '3'},
-                                 {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2], 'prev': '2', 'next': '4'},
-                                 {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3], 'prev': '3', 'next': '5'},
-                                 {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4], 'rotation': [1, 0, 0, 0],
-                                  'prev': '4', 'next': '6'},
-                                 {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5], 'prev': '5', 'next': ''}]
+        self.mock_annotations = [
+            {'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0],
+             'rotation': [1, 0, 0, 0], 'prev': '', 'next': '2'},
+            {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1],
+             'prev': '1', 'next': '3'},
+            {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2],
+             'prev': '2', 'next': '4'},
+            {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3],
+             'prev': '3', 'next': '5'},
+            {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4],
+             'rotation': [1, 0, 0, 0], 'prev': '4', 'next': '6'},
+            {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5],
+             'prev': '5', 'next': ''}
+            ]
 
-        self.multiagent_mock_annotations = [{'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0], 'rotation': [1, 0, 0, 0],
-                                             'prev': '', 'next': '2'},
-                                            {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1], 'prev': '1', 'next': '3'},
-                                            {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2], 'prev': '2', 'next': '4'},
-                                            {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3], 'prev': '3', 'next': '5'},
-                                            {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4], 'rotation': [1, 0, 0, 0],
-                                             'prev': '4', 'next': '6'},
-                                            {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5], 'prev': '5', 'next': ''},
-                                            {'token': '1b', 'instance_token': '2', 'sample_token': '1', 'translation': [6, 6, 6], 'rotation': [1, 0, 0, 0],
-                                             'prev': '', 'next': '2b'},
-                                            {'token': '2b', 'instance_token': '2', 'sample_token': '2', 'translation': [7, 7, 7], 'prev': '1b', 'next': '3b'},
-                                            {'token': '3b', 'instance_token': '2', 'sample_token': '3', 'translation': [8, 8, 8], 'prev': '2b', 'next': '4b'},
-                                            {'token': '4b', 'instance_token': '2', 'sample_token': '4', 'translation': [9, 9, 9], 'prev': '3b', 'next': '5b'},
-                                            {'token': '5b', 'instance_token': '2', 'sample_token': '5', 'translation': [10, 10, 10], 'rotation': [1, 0, 0, 0],
-                                            'prev': '4b', 'next': '6b'},
-                                            {'token': '6b', 'instance_token': '2', 'sample_token': '6', 'translation': [11, 11, 11], 'prev': '5b', 'next': ''}]
-
+        self.multiagent_mock_annotations = [
+            {'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0],
+             'rotation': [1, 0, 0, 0], 'prev': '', 'next': '2'},
+            {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1],
+             'prev': '1', 'next': '3'},
+            {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2],
+             'prev': '2', 'next': '4'},
+            {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3],
+             'prev': '3', 'next': '5'},
+            {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4],
+             'rotation': [1, 0, 0, 0], 'prev': '4', 'next': '6'},
+            {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5],
+             'prev': '5', 'next': ''},
+            {'token': '1b', 'instance_token': '2', 'sample_token': '1', 'translation': [6, 6, 6],
+             'rotation': [1, 0, 0, 0], 'prev': '', 'next': '2b'},
+            {'token': '2b', 'instance_token': '2', 'sample_token': '2', 'translation': [7, 7, 7],
+             'prev': '1b', 'next': '3b'},
+            {'token': '3b', 'instance_token': '2', 'sample_token': '3', 'translation': [8, 8, 8],
+             'prev': '2b', 'next': '4b'},
+            {'token': '4b', 'instance_token': '2', 'sample_token': '4', 'translation': [9, 9, 9],
+             'prev': '3b', 'next': '5b'},
+            {'token': '5b', 'instance_token': '2', 'sample_token': '5', 'translation': [10, 10, 10],
+             'rotation': [1, 0, 0, 0], 'prev': '4b', 'next': '6b'},
+            {'token': '6b', 'instance_token': '2', 'sample_token': '6', 'translation': [11, 11, 11],
+             'prev': '5b', 'next': ''}
+        ]
 
     def test_get_sample_annotation(self,):
 
@@ -283,7 +304,6 @@ class TestPredictHelper(unittest.TestCase):
 
         helper = PredictHelper(nusc)
         self.assertDictEqual(mock_annotation, helper.get_sample_annotation('instance_1', 'sample_1'))
-
 
     def test_get_future_for_agent_exact_amount(self,):
 
@@ -468,7 +488,7 @@ class TestPredictHelper(unittest.TestCase):
 
         nusc = MockNuScenes(self.multiagent_mock_annotations, mock_samples)
         helper = PredictHelper(nusc)
-        past = helper.get_past_for_sample('5', 3, True)
+        past = helper.get_past_for_sample('5', 3, True)  # TODO: Past not used.
 
         answer = {'1': np.array([[-1, -1], [-2, -2], [-3, -3]]),
                   '2': np.array([[-1, -1], [-2, -2], [-3, -3]])}

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -284,6 +284,7 @@ class TestPredictHelper(unittest.TestCase):
         helper = PredictHelper(nusc)
         self.assertDictEqual(mock_annotation, helper.get_sample_annotation('instance_1', 'sample_1'))
 
+
     def test_get_future_for_agent_exact_amount(self,):
 
         mock_samples = [{'token': '1', 'timestamp': 0},
@@ -475,4 +476,28 @@ class TestPredictHelper(unittest.TestCase):
         for k in answer:
             np.testing.assert_equal(answer[k], answer[k])
 
+    def test_get_no_data_when_seconds_0(self):
+        mock_samples = [{'token': '1', 'timestamp': 0, 'anns': ['1']}]
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
 
+        np.testing.assert_equal(helper.get_future_for_agent('1', '1', 0, False), np.array([]))
+        np.testing.assert_equal(helper.get_past_for_agent('1', '1', 0, False), np.array([]))
+        np.testing.assert_equal(helper.get_future_for_sample('1', 0, False), np.array([]))
+        np.testing.assert_equal(helper.get_past_for_sample('1', 0, False), np.array([]))
+
+    def test_raises_error_when_seconds_negative(self):
+        mock_samples = [{'token': '1', 'timestamp': 0, 'anns': ['1', '1b']}]
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        with self.assertRaises(ValueError):
+            helper.get_future_for_agent('1', '1', -1, False)
+
+        with self.assertRaises(ValueError):
+            helper.get_past_for_agent('1', '1', -1, False)
+
+        with self.assertRaises(ValueError):
+            helper.get_past_for_sample('1', -1, False)
+
+        with self.assertRaises(ValueError):
+            helper.get_future_for_sample('1', -1, False)

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -1,0 +1,475 @@
+import unittest
+from typing import Dict, List, Any
+from nuscenes.predict import PredictHelper, convert_global_coords_to_local
+import numpy as np
+
+class MockNuScenes:
+    """Mocks the NuScenes API needed to test PredictHelper"""
+
+    def __init__(self, sample_annotations: List[Dict[str, Any]],
+                 samples: List[Dict[str, Any]]):
+
+        self._sample_annotation = {r['token']: r for r in sample_annotations}
+        self._sample = {r['token']: r for r in samples}
+
+    @property
+    def sample_annotation(self,) -> List[Dict[str, Any]]:
+        return list(self._sample_annotation.values())
+
+    def get(self, table_name: str, token: str) -> Dict[str, Any]:
+        assert table_name in {'sample_annotation', 'sample'}
+        return getattr(self, "_" + table_name)[token]
+
+class Test_convert_global_coords_to_local(unittest.TestCase):
+
+    def setUp(self):
+        along_pos_x = np.zeros((5, 2))
+        along_pos_y = np.zeros((5, 2))
+        along_neg_x = np.zeros((5, 2))
+        along_neg_y = np.zeros((5, 2))
+
+        along_pos_x[:, 0] = np.arange(1, 6)
+        along_pos_y[:, 1] = np.arange(1, 6)
+        along_neg_x[:, 0] = -np.arange(1, 6)
+        along_neg_y[:, 1] = -np.arange(1, 6)
+        self.along_pos_x, self.along_pos_y = along_pos_x, along_pos_y
+        self.along_neg_x, self.along_neg_y = along_neg_x, along_neg_y
+
+        y_equals_x = np.zeros((5, 2))
+        y_equals_x[:, 0] = np.arange(1, 6)
+        y_equals_x[:, 1] = np.arange(1, 6)
+        self.y_equals_x = y_equals_x
+
+    def test_heading_0(self):
+        rotation = (1, 0, 0, 0)
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y, atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x, atol=1e-4)
+
+    def test_heading_pi_over_4(self):
+        rotation = (np.cos(np.pi / 8), 0, 0, np.sin(np.pi / 8))
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * np.sqrt(2) / 2, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * np.sqrt(2) / 2, atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer,  self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer,  self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer,  self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer,  self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+    def test_heading_pi_over_2(self):
+        rotation = (np.cos(np.pi / 4), 0, 0, np.sin(np.pi / 4))
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x,  atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y, atol=1e-4)
+
+    def test_heading_3pi_over_4(self):
+        rotation = (np.cos(3 * np.pi / 8), 0, 0, np.sin(3 * np.pi / 8))
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]],  atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+    def test_heading_pi(self):
+        rotation = (np.cos(np.pi / 2), 0, 0, np.sin(np.pi / 2))
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_y,  atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_x, atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_pos_y, atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.along_neg_x, atol=1e-4)
+
+    def test_heading_neg_pi_over_4(self):
+        rotation = (np.cos(-np.pi / 8), 0, 0, np.sin(-np.pi / 8))
+        origin = (0, 0, 0)
+        offset = (50, 25, 0)
+
+        # Testing path along pos x direction
+        answer = convert_global_coords_to_local(self.along_pos_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, np.sqrt(2) / 2]],  atol=1e-4)
+
+        # Testing path along pos y direction
+        answer = convert_global_coords_to_local(self.along_pos_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_pos_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[-np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg x direction
+        answer = convert_global_coords_to_local(self.along_neg_x, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_x + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, -np.sqrt(2) / 2]], atol=1e-4)
+
+        # Testing path along neg y direction
+        answer = convert_global_coords_to_local(self.along_neg_y, origin, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+        answer = convert_global_coords_to_local(self.along_neg_y + [[50, 25]], offset, rotation)
+        np.testing.assert_allclose(answer, self.y_equals_x * [[np.sqrt(2) / 2, np.sqrt(2) / 2]], atol=1e-4)
+
+
+class TestPredictHelper(unittest.TestCase):
+
+    def setUp(self):
+
+        self.mock_annotations = [{'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0], 'rotation': [1, 0, 0, 0],
+                                  'prev': '', 'next': '2'},
+                                 {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1], 'prev': '1', 'next': '3'},
+                                 {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2], 'prev': '2', 'next': '4'},
+                                 {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3], 'prev': '3', 'next': '5'},
+                                 {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4], 'rotation': [1, 0, 0, 0],
+                                  'prev': '4', 'next': '6'},
+                                 {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5], 'prev': '5', 'next': ''}]
+
+        self.multiagent_mock_annotations = [{'token': '1', 'instance_token': '1', 'sample_token': '1', 'translation': [0, 0, 0], 'rotation': [1, 0, 0, 0],
+                                             'prev': '', 'next': '2'},
+                                            {'token': '2', 'instance_token': '1', 'sample_token': '2', 'translation': [1, 1, 1], 'prev': '1', 'next': '3'},
+                                            {'token': '3', 'instance_token': '1', 'sample_token': '3', 'translation': [2, 2, 2], 'prev': '2', 'next': '4'},
+                                            {'token': '4', 'instance_token': '1', 'sample_token': '4', 'translation': [3, 3, 3], 'prev': '3', 'next': '5'},
+                                            {'token': '5', 'instance_token': '1', 'sample_token': '5', 'translation': [4, 4, 4], 'rotation': [1, 0, 0, 0],
+                                             'prev': '4', 'next': '6'},
+                                            {'token': '6', 'instance_token': '1', 'sample_token': '6', 'translation': [5, 5, 5], 'prev': '5', 'next': ''},
+                                            {'token': '1b', 'instance_token': '2', 'sample_token': '1', 'translation': [6, 6, 6], 'rotation': [1, 0, 0, 0],
+                                             'prev': '', 'next': '2b'},
+                                            {'token': '2b', 'instance_token': '2', 'sample_token': '2', 'translation': [7, 7, 7], 'prev': '1b', 'next': '3b'},
+                                            {'token': '3b', 'instance_token': '2', 'sample_token': '3', 'translation': [8, 8, 8], 'prev': '2b', 'next': '4b'},
+                                            {'token': '4b', 'instance_token': '2', 'sample_token': '4', 'translation': [9, 9, 9], 'prev': '3b', 'next': '5b'},
+                                            {'token': '5b', 'instance_token': '2', 'sample_token': '5', 'translation': [10, 10, 10], 'rotation': [1, 0, 0, 0],
+                                            'prev': '4b', 'next': '6b'},
+                                            {'token': '6b', 'instance_token': '2', 'sample_token': '6', 'translation': [11, 11, 11], 'prev': '5b', 'next': ''}]
+
+
+    def test_get_sample_annotation(self,):
+
+        mock_annotation = {'token': '1', 'instance_token': 'instance_1',
+                           'sample_token': 'sample_1'}
+        mock_sample = {'token': 'sample_1', 'timestamp': 0}
+
+        nusc = MockNuScenes([mock_annotation], [mock_sample])
+
+        helper = PredictHelper(nusc)
+        self.assertDictEqual(mock_annotation, helper.get_sample_annotation('instance_1', 'sample_1'))
+
+    def test_get_future_for_agent_exact_amount(self,):
+
+        mock_samples = [{'token': '1', 'timestamp': 0},
+                        {'token': '2', 'timestamp': 1e6},
+                        {'token': '3', 'timestamp': 2e6},
+                        {'token': '4', 'timestamp': 3e6},
+                        {'token': '5', 'timestamp': 4e6}]
+
+        # Testing we can get the exact amount of future seconds available
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '1', 3, False)
+        np.testing.assert_equal(future, np.array([[1, 1], [2, 2], [3, 3]]))
+
+    def test_get_future_for_agent_in_agent_frame(self):
+        mock_samples = [{'token': '1', 'timestamp': 0},
+                        {'token': '2', 'timestamp': 1e6},
+                        {'token': '3', 'timestamp': 2e6},
+                        {'token': '4', 'timestamp': 3e6},
+                        {'token': '5', 'timestamp': 4e6}]
+
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '1', 3, True)
+        np.testing.assert_allclose(future, np.array([[-1, 1], [-2, 2], [-3, 3]]))
+
+    def test_get_future_for_agent_less_amount(self,):
+
+        mock_samples = [{'token': '1', 'timestamp': 0},
+                        {'token': '2', 'timestamp': 1e6},
+                        {'token': '3', 'timestamp': 2.6e6},
+                        {'token': '4', 'timestamp': 4e6},
+                        {'token': '5', 'timestamp': 5.5e6}]
+
+        # Testing we do not include data after the future seconds
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '1', 3, False)
+        np.testing.assert_equal(future, np.array([[1, 1], [2, 2]]))
+
+    def test_get_future_for_agent_within_buffer(self,):
+
+        mock_samples = [{'token': '1', 'timestamp': 0},
+                        {'token': '2', 'timestamp': 1e6},
+                        {'token': '3', 'timestamp': 2.6e6},
+                        {'token': '4', 'timestamp': 3.05e6},
+                        {'token': '5', 'timestamp': 3.5e6}]
+
+        # Testing we get data if it is after future seconds but within buffer
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '1', 3, False)
+        np.testing.assert_equal(future, np.array([[1, 1], [2, 2], [3, 3]]))
+
+    def test_get_future_for_agent_no_data_to_get(self,):
+        mock_samples = [{'token': '1', 'timestamp': 0},
+                        {'token': '2', 'timestamp': 3.5e6}]
+
+        # Testing we get nothing if the first sample annotation is past our threshold
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '1', 3, False)
+        np.testing.assert_equal(future, np.array([]))
+
+    def test_get_future_for_last_returns_nothing(self):
+        mock_samples = [{'token': '6', 'timestamp': 0}]
+
+        # Testing we get nothing if we're at the last annotation
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_agent('1', '6', 3, False)
+        np.testing.assert_equal(future, np.array([]))
+
+    def test_get_past_for_agent_exact_amount(self,):
+
+        mock_samples = [{'token': '5', 'timestamp': 0},
+                        {'token': '4', 'timestamp': -1e6},
+                        {'token': '3', 'timestamp': -2e6},
+                        {'token': '2', 'timestamp': -3e6},
+                        {'token': '1', 'timestamp': -4e6}]
+
+        # Testing we can get the exact amount of past seconds available
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '5', 3, False)
+        np.testing.assert_equal(past, np.array([[3, 3], [2, 2], [1, 1]]))
+
+    def test_get_past_for_agent_in_frame(self,):
+
+        mock_samples = [{'token': '5', 'timestamp': 0},
+                        {'token': '4', 'timestamp': -1e6},
+                        {'token': '3', 'timestamp': -2e6},
+                        {'token': '2', 'timestamp': -3e6},
+                        {'token': '1', 'timestamp': -4e6}]
+
+        # Testing we can get the exact amount of past seconds available
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '5', 3, True)
+        np.testing.assert_allclose(past, np.array([[1., -1.], [2., -2.], [3., -3.]]))
+
+    def test_get_past_for_agent_less_amount(self,):
+
+        mock_samples = [{'token': '5', 'timestamp': 0},
+                        {'token': '4', 'timestamp': -1e6},
+                        {'token': '3', 'timestamp': -2.6e6},
+                        {'token': '2', 'timestamp': -4e6},
+                        {'token': '1', 'timestamp': -5.5e6}]
+
+        # Testing we do not include data after the past seconds
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '5', 3, False)
+        np.testing.assert_equal(past, np.array([[3, 3], [2, 2]]))
+
+    def test_get_past_for_agent_within_buffer(self,):
+
+        mock_samples = [{'token': '5', 'timestamp': 0},
+                        {'token': '4', 'timestamp': -1e6},
+                        {'token': '3', 'timestamp': -3.05e6},
+                        {'token': '2', 'timestamp': -3.2e6}]
+
+        # Testing we get data if it is after future seconds but within buffer
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '5', 3, False)
+        np.testing.assert_equal(past, np.array([[3, 3], [2, 2]]))
+
+    def test_get_past_for_agent_no_data_to_get(self,):
+        mock_samples = [{'token': '5', 'timestamp': 0},
+                        {'token': '4', 'timestamp': -3.5e6}]
+
+        # Testing we get nothing if the first sample annotation is past our threshold
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '5', 3, False)
+        np.testing.assert_equal(past, np.array([]))
+
+    def test_get_past_for_last_returns_nothing(self):
+        mock_samples = [{'token': '1', 'timestamp': 0}]
+
+        # Testing we get nothing if we're at the last annotation
+        nusc = MockNuScenes(self.mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_agent('1', '1', 3, False)
+        np.testing.assert_equal(past, np.array([]))
+
+    def test_get_future_for_sample(self):
+
+        mock_samples = [{'token': '1', 'timestamp': 0, 'anns': ['1', '1b']},
+                        {'token': '2', 'timestamp': 1e6},
+                        {'token': '3', 'timestamp': 2e6},
+                        {'token': '4', 'timestamp': 3e6},
+                        {'token': '5', 'timestamp': 4e6}]
+
+        nusc = MockNuScenes(self.multiagent_mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        future = helper.get_future_for_sample("1", 3, False)
+
+        answer = {'1': np.array([[1, 1], [2, 2], [3, 3]]),
+                  '2': np.array([[7, 7], [8, 8], [9, 9]])}
+
+        for k in answer:
+            np.testing.assert_equal(answer[k], future[k])
+
+        future_in_sample = helper.get_future_for_sample("1", 3, True)
+
+        answer_in_sample = {'1': np.array([[-1, 1], [-2, 2], [-3, 3]]),
+                            '2': np.array([[-1, 1], [-2, 2], [-3, 3]])}
+
+        for k in answer_in_sample:
+            np.testing.assert_allclose(answer_in_sample[k], future_in_sample[k])
+
+    def test_get_past_for_sample(self):
+
+        mock_samples = [{'token': '5', 'timestamp': 0, 'anns': ['5', '5b']},
+                        {'token': '4', 'timestamp': -1e6},
+                        {'token': '3', 'timestamp': -2e6},
+                        {'token': '2', 'timestamp': -3e6},
+                        {'token': '1', 'timestamp': -4e6}]
+
+        nusc = MockNuScenes(self.multiagent_mock_annotations, mock_samples)
+        helper = PredictHelper(nusc)
+        past = helper.get_past_for_sample('5', 3, True)
+
+        answer = {'1': np.array([[-1, -1], [-2, -2], [-3, -3]]),
+                  '2': np.array([[-1, -1], [-2, -2], [-3, -3]])}
+
+        for k in answer:
+            np.testing.assert_equal(answer[k], answer[k])
+
+

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -21,7 +21,7 @@ class MockNuScenes(NuScenes):
         self._sample = {r['token']: r for r in samples}
 
     @property
-    def sample_annotation(self,) -> List[Dict[str, Any]]:
+    def sample_annotation(self) -> List[Dict[str, Any]]:
         return list(self._sample_annotation.values())
 
     def get(self, table_name: str, token: str) -> Dict[str, Any]:
@@ -294,10 +294,9 @@ class TestPredictHelper(unittest.TestCase):
              'prev': '5b', 'next': ''}
         ]
 
-    def test_get_sample_annotation(self,):
+    def test_get_sample_annotation(self):
 
-        mock_annotation = {'token': '1', 'instance_token': 'instance_1',
-                           'sample_token': 'sample_1'}
+        mock_annotation = {'token': '1', 'instance_token': 'instance_1', 'sample_token': 'sample_1'}
         mock_sample = {'token': 'sample_1', 'timestamp': 0}
 
         nusc = MockNuScenes([mock_annotation], [mock_sample])
@@ -305,7 +304,7 @@ class TestPredictHelper(unittest.TestCase):
         helper = PredictHelper(nusc)
         self.assertDictEqual(mock_annotation, helper.get_sample_annotation('instance_1', 'sample_1'))
 
-    def test_get_future_for_agent_exact_amount(self,):
+    def test_get_future_for_agent_exact_amount(self):
 
         mock_samples = [{'token': '1', 'timestamp': 0},
                         {'token': '2', 'timestamp': 1e6},
@@ -331,7 +330,7 @@ class TestPredictHelper(unittest.TestCase):
         future = helper.get_future_for_agent('1', '1', 3, True)
         np.testing.assert_allclose(future, np.array([[-1, 1], [-2, 2], [-3, 3]]))
 
-    def test_get_future_for_agent_less_amount(self,):
+    def test_get_future_for_agent_less_amount(self):
 
         mock_samples = [{'token': '1', 'timestamp': 0},
                         {'token': '2', 'timestamp': 1e6},
@@ -345,7 +344,7 @@ class TestPredictHelper(unittest.TestCase):
         future = helper.get_future_for_agent('1', '1', 3, False)
         np.testing.assert_equal(future, np.array([[1, 1], [2, 2]]))
 
-    def test_get_future_for_agent_within_buffer(self,):
+    def test_get_future_for_agent_within_buffer(self):
 
         mock_samples = [{'token': '1', 'timestamp': 0},
                         {'token': '2', 'timestamp': 1e6},
@@ -359,7 +358,7 @@ class TestPredictHelper(unittest.TestCase):
         future = helper.get_future_for_agent('1', '1', 3, False)
         np.testing.assert_equal(future, np.array([[1, 1], [2, 2], [3, 3]]))
 
-    def test_get_future_for_agent_no_data_to_get(self,):
+    def test_get_future_for_agent_no_data_to_get(self):
         mock_samples = [{'token': '1', 'timestamp': 0},
                         {'token': '2', 'timestamp': 3.5e6}]
 
@@ -378,7 +377,7 @@ class TestPredictHelper(unittest.TestCase):
         future = helper.get_future_for_agent('1', '6', 3, False)
         np.testing.assert_equal(future, np.array([]))
 
-    def test_get_past_for_agent_exact_amount(self,):
+    def test_get_past_for_agent_exact_amount(self):
 
         mock_samples = [{'token': '5', 'timestamp': 0},
                         {'token': '4', 'timestamp': -1e6},
@@ -392,7 +391,7 @@ class TestPredictHelper(unittest.TestCase):
         past = helper.get_past_for_agent('1', '5', 3, False)
         np.testing.assert_equal(past, np.array([[3, 3], [2, 2], [1, 1]]))
 
-    def test_get_past_for_agent_in_frame(self,):
+    def test_get_past_for_agent_in_frame(self):
 
         mock_samples = [{'token': '5', 'timestamp': 0},
                         {'token': '4', 'timestamp': -1e6},
@@ -406,7 +405,7 @@ class TestPredictHelper(unittest.TestCase):
         past = helper.get_past_for_agent('1', '5', 3, True)
         np.testing.assert_allclose(past, np.array([[1., -1.], [2., -2.], [3., -3.]]))
 
-    def test_get_past_for_agent_less_amount(self,):
+    def test_get_past_for_agent_less_amount(self):
 
         mock_samples = [{'token': '5', 'timestamp': 0},
                         {'token': '4', 'timestamp': -1e6},
@@ -420,7 +419,7 @@ class TestPredictHelper(unittest.TestCase):
         past = helper.get_past_for_agent('1', '5', 3, False)
         np.testing.assert_equal(past, np.array([[3, 3], [2, 2]]))
 
-    def test_get_past_for_agent_within_buffer(self,):
+    def test_get_past_for_agent_within_buffer(self):
 
         mock_samples = [{'token': '5', 'timestamp': 0},
                         {'token': '4', 'timestamp': -1e6},
@@ -433,7 +432,7 @@ class TestPredictHelper(unittest.TestCase):
         past = helper.get_past_for_agent('1', '5', 3, False)
         np.testing.assert_equal(past, np.array([[3, 3], [2, 2]]))
 
-    def test_get_past_for_agent_no_data_to_get(self,):
+    def test_get_past_for_agent_no_data_to_get(self):
         mock_samples = [{'token': '5', 'timestamp': 0},
                         {'token': '4', 'timestamp': -3.5e6}]
 

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -461,7 +461,7 @@ class TestPredictHelper(unittest.TestCase):
 
         nusc = MockNuScenes(self.multiagent_mock_annotations, mock_samples)
         helper = PredictHelper(nusc)
-        future = helper.get_future_for_sample("1", 3, False)
+        future = helper.get_future_for_sample('1', 3, False)
 
         answer = {'1': np.array([[1, 1], [2, 2], [3, 3]]),
                   '2': np.array([[7, 7], [8, 8], [9, 9]])}
@@ -469,7 +469,7 @@ class TestPredictHelper(unittest.TestCase):
         for k in answer:
             np.testing.assert_equal(answer[k], future[k])
 
-        future_in_sample = helper.get_future_for_sample("1", 3, True)
+        future_in_sample = helper.get_future_for_sample('1', 3, True)
 
         answer_in_sample = {'1': np.array([[-1, 1], [-2, 2], [-3, 3]]),
                             '2': np.array([[-1, 1], [-2, 2], [-3, 3]])}


### PR DESCRIPTION
Adds a PredictHelper class for getting the future and past of an agent given its instance token and one of its sample tokens. 

@holger-nutonomy, I've created a base branch for the challenge called `nuscenes-predict-challenge`. Let me know if this is ok with you.

How to test:
`nosetests nuscenes/tests`

FYI: @emwolff 