### PR TITLE
Map API: Return all axes, not just one

### DIFF
--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -315,7 +315,7 @@ class NuScenesMap:
                         layer_names: List[str] = None,
                         canvas_size: Tuple[int, int] = (100, 100),
                         figsize: Tuple[int, int] = (15, 15),
-                        n_row: int = 2) -> Tuple[Figure, Axes]:
+                        n_row: int = 2) -> Tuple[Figure, List[Axes]]:
         """
         Render map mask of the patch specified by patch_box and patch_angle.
         :param patch_box: Patch box defined as [x_center, y_center, height, width].
@@ -475,7 +475,7 @@ class NuScenesMapExplorer:
                         layer_names: List[str],
                         canvas_size: Tuple[int, int],
                         figsize: Tuple[int, int],
-                        n_row: int = 2) -> Tuple[Figure, Axes]:
+                        n_row: int = 2) -> Tuple[Figure, List[Axes]]:
         """
         Render map mask of the patch specified by patch_box, and patch_angle.
         :param patch_box: Patch box defined as [x_center, y_center, height, width].
@@ -506,12 +506,12 @@ class NuScenesMapExplorer:
         for i in range(len(map_mask)):
             r = i // n_col
             c = i - r * n_col
-            ax = plt.subplot(gs[r, c])
-            ax.imshow(map_mask[i], origin='lower')
-            ax.text(canvas_size[0] * 0.5, canvas_size[1] * 1.1, layer_names[i])
-            ax.grid(False)
+            subax = plt.subplot(gs[r, c])
+            subax.imshow(map_mask[i], origin='lower')
+            subax.text(canvas_size[0] * 0.5, canvas_size[1] * 1.1, layer_names[i])
+            subax.grid(False)
 
-        return fig, ax
+        return fig, fig.axes
 
     def get_map_geom(self,
                      patch_box: Tuple[float, float, float, float],

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -324,7 +324,7 @@ class NuScenesMap:
         :param canvas_size: Size of the output mask (h, w).
         :param figsize: Size of the figure.
         :param n_row: Number of rows with plots.
-        :return: The matplotlib figure and axes of the rendered layers.
+        :return: The matplotlib figure and a list of axes of the rendered layers.
         """
         return self.explorer.render_map_mask(patch_box, patch_angle, layer_names, canvas_size,
                                              figsize=figsize, n_row=n_row)
@@ -477,14 +477,14 @@ class NuScenesMapExplorer:
                         figsize: Tuple[int, int],
                         n_row: int = 2) -> Tuple[Figure, List[Axes]]:
         """
-        Render map mask of the patch specified by patch_box, and patch_angle.
+        Render map mask of the patch specified by patch_box and patch_angle.
         :param patch_box: Patch box defined as [x_center, y_center, height, width].
         :param patch_angle: Patch orientation in degrees.
         :param layer_names: A list of layer names to be extracted.
         :param canvas_size: Size of the output mask (h, w).
         :param figsize: Size of the figure.
         :param n_row: Number of rows with plots.
-        :return: The matplotlib figure and axes of the rendered layers.
+        :return: The matplotlib figure and a list of axes of the rendered layers.
         """
         if layer_names is None:
             layer_names = self.map_api.non_geometric_layers


### PR DESCRIPTION
This PR addresses an inconsistency in the Map API as discovered in https://github.com/nutonomy/nuscenes-devkit/issues/281. Despite rendering multiple plots, only a single axis is returned by the function.

The result was tested by rendering the map-tutorial.