### PR TITLE
Disable slow unittests

### DIFF
--- a/python-sdk/nuscenes/eval/common/data_classes.py
+++ b/python-sdk/nuscenes/eval/common/data_classes.py
@@ -1,9 +1,9 @@
 # nuScenes dev-kit.
 # Code written by Holger Caesar & Oscar Beijbom, 2019.
 
+import abc
 from collections import defaultdict
 from typing import List, Tuple, Union
-import abc
 
 import numpy as np
 

--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -5,15 +5,15 @@ import json
 from typing import Dict, Tuple
 
 import numpy as np
-from pyquaternion import Quaternion
 import tqdm
+from pyquaternion import Quaternion
 
 from nuscenes import NuScenes
 from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.eval.detection.utils import category_to_detection_name
 from nuscenes.eval.detection.data_classes import DetectionBox
-from nuscenes.eval.tracking.utils import category_to_tracking_name
+from nuscenes.eval.detection.utils import category_to_detection_name
 from nuscenes.eval.tracking.data_classes import TrackingBox
+from nuscenes.eval.tracking.utils import category_to_tracking_name
 from nuscenes.utils.data_classes import Box
 from nuscenes.utils.geometry_utils import points_in_box
 from nuscenes.utils.splits import create_splits_scenes

--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -6,8 +6,8 @@ from typing import Callable
 import numpy as np
 
 from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.eval.detection.data_classes import DetectionMetricData
 from nuscenes.eval.common.utils import center_distance, scale_iou, yaw_diff, velocity_l2, attr_acc, cummean
+from nuscenes.eval.detection.data_classes import DetectionMetricData
 
 
 def accumulate(gt_boxes: EvalBoxes,

--- a/python-sdk/nuscenes/eval/detection/evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/evaluate.py
@@ -11,14 +11,14 @@ from typing import Tuple, Dict, Any
 import numpy as np
 
 from nuscenes import NuScenes
+from nuscenes.eval.common.config import config_factory
+from nuscenes.eval.common.data_classes import EvalBoxes
+from nuscenes.eval.common.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
 from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp
 from nuscenes.eval.detection.constants import TP_METRICS
 from nuscenes.eval.detection.data_classes import DetectionConfig, DetectionMetrics, DetectionBox, \
     DetectionMetricDataList
-from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.eval.common.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
 from nuscenes.eval.detection.render import summary_plot, class_pr_curve, class_tp_curve, dist_pr_curve, visualize_sample
-from nuscenes.eval.common.config import config_factory
 
 
 class DetectionEval:

--- a/python-sdk/nuscenes/eval/detection/render.py
+++ b/python-sdk/nuscenes/eval/detection/render.py
@@ -9,11 +9,11 @@ from matplotlib import pyplot as plt
 
 from nuscenes import NuScenes
 from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.eval.common.utils import boxes_to_sensor
 from nuscenes.eval.common.render import setup_axis
-from nuscenes.eval.detection.data_classes import DetectionMetrics, DetectionMetricData, DetectionMetricDataList
+from nuscenes.eval.common.utils import boxes_to_sensor
 from nuscenes.eval.detection.constants import TP_METRICS, DETECTION_NAMES, DETECTION_COLORS, TP_METRICS_UNITS, \
     PRETTY_DETECTION_NAMES, PRETTY_TP_METRICS
+from nuscenes.eval.detection.data_classes import DetectionMetrics, DetectionMetricData, DetectionMetricDataList
 from nuscenes.utils.data_classes import LidarPointCloud
 from nuscenes.utils.geometry_utils import view_points
 

--- a/python-sdk/nuscenes/eval/detection/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_algo.py
@@ -8,14 +8,14 @@ from typing import Dict, List
 import numpy as np
 from pyquaternion import Quaternion
 
+from nuscenes.eval.common.config import config_factory
+from nuscenes.eval.common.data_classes import EvalBoxes
+from nuscenes.eval.common.utils import center_distance
 from nuscenes.eval.detection.algo import accumulate, calc_ap, calc_tp
 from nuscenes.eval.detection.constants import TP_METRICS
 from nuscenes.eval.detection.data_classes import DetectionMetrics, DetectionMetricData, DetectionBox, \
     DetectionMetricDataList
 from nuscenes.eval.detection.utils import detection_name_to_rel_attributes
-from nuscenes.eval.common.config import config_factory
-from nuscenes.eval.common.utils import center_distance
-from nuscenes.eval.common.data_classes import EvalBoxes
 
 
 class TestAlgo(unittest.TestCase):

--- a/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
@@ -13,9 +13,9 @@ from tqdm import tqdm
 
 from nuscenes import NuScenes
 from nuscenes.eval.common.config import config_factory
+from nuscenes.eval.detection.constants import DETECTION_NAMES
 from nuscenes.eval.detection.evaluate import DetectionEval
 from nuscenes.eval.detection.utils import category_to_detection_name, detection_name_to_rel_attributes
-from nuscenes.eval.detection.constants import DETECTION_NAMES
 from nuscenes.utils.splits import create_splits_scenes
 
 

--- a/python-sdk/nuscenes/eval/tracking/evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/evaluate.py
@@ -12,13 +12,13 @@ import numpy as np
 from nuscenes import NuScenes
 from nuscenes.eval.common.config import config_factory
 from nuscenes.eval.common.loaders import load_prediction, load_gt, add_center_dist, filter_eval_boxes
+from nuscenes.eval.tracking.algo import TrackingEvaluation
+from nuscenes.eval.tracking.constants import AVG_METRIC_MAP, MOT_METRIC_MAP, LEGACY_METRICS
 from nuscenes.eval.tracking.data_classes import TrackingMetrics, TrackingMetricDataList, TrackingConfig, TrackingBox, \
     TrackingMetricData
-from nuscenes.eval.tracking.algo import TrackingEvaluation
 from nuscenes.eval.tracking.loaders import create_tracks
-from nuscenes.eval.tracking.utils import print_final_metrics
-from nuscenes.eval.tracking.constants import AVG_METRIC_MAP, MOT_METRIC_MAP, LEGACY_METRICS
 from nuscenes.eval.tracking.render import recall_metric_curve, summary_plot
+from nuscenes.eval.tracking.utils import print_final_metrics
 
 
 class TrackingEval:

--- a/python-sdk/nuscenes/eval/tracking/loaders.py
+++ b/python-sdk/nuscenes/eval/tracking/loaders.py
@@ -2,16 +2,16 @@
 # Code written by Holger Caesar, Caglayan Dicle and Oscar Beijbom, 2019.
 
 from bisect import bisect
-from typing import List, Dict, DefaultDict
 from collections import defaultdict
+from typing import List, Dict, DefaultDict
 
 import numpy as np
 from pyquaternion import Quaternion
 
 from nuscenes.eval.common.data_classes import EvalBoxes
-from nuscenes.utils.splits import create_splits_scenes
 from nuscenes.eval.tracking.data_classes import TrackingBox
 from nuscenes.nuscenes import NuScenes
+from nuscenes.utils.splits import create_splits_scenes
 
 
 def interpolate_tracking_boxes(left_box: TrackingBox, right_box: TrackingBox, right_ratio: float) -> TrackingBox:

--- a/python-sdk/nuscenes/eval/tracking/metrics.py
+++ b/python-sdk/nuscenes/eval/tracking/metrics.py
@@ -8,6 +8,7 @@ py-motmetrics at:
 https://github.com/cheind/py-motmetrics
 """
 from typing import Any
+
 import numpy as np
 
 DataFrame = Any

--- a/python-sdk/nuscenes/eval/tracking/render.py
+++ b/python-sdk/nuscenes/eval/tracking/render.py
@@ -3,15 +3,15 @@
 
 import os
 from typing import Any, List
-from pandas import DataFrame
 
 import matplotlib.pyplot as plt
 import numpy as np
+from pandas import DataFrame
 from pyquaternion import Quaternion
-from nuscenes.eval.common.render import setup_axis
-from nuscenes.eval.tracking.data_classes import TrackingBox, TrackingMetricDataList
-from nuscenes.eval.tracking.constants import TRACKING_COLORS, PRETTY_TRACKING_NAMES
 
+from nuscenes.eval.common.render import setup_axis
+from nuscenes.eval.tracking.constants import TRACKING_COLORS, PRETTY_TRACKING_NAMES
+from nuscenes.eval.tracking.data_classes import TrackingBox, TrackingMetricDataList
 from nuscenes.utils.data_classes import Box
 
 Axis = Any

--- a/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
@@ -1,7 +1,7 @@
-import unittest
-from typing import Tuple, Dict, List
 import copy
+import unittest
 from collections import defaultdict
+from typing import Tuple, Dict, List
 
 import numpy as np
 

--- a/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
@@ -133,6 +133,7 @@ class TestMain(unittest.TestCase):
         }
         return mock_submission
 
+    @unittest.skip
     def basic_test(self,
                    eval_set: str = 'mini_val',
                    add_errors: bool = False,
@@ -168,6 +169,7 @@ class TestMain(unittest.TestCase):
 
         return metrics
 
+    @unittest.skip
     def test_delta_mock(self,
                         eval_set: str = 'mini_val',
                         render_curves: bool = False):
@@ -191,6 +193,7 @@ class TestMain(unittest.TestCase):
         else:
             print('Skipping checks due to choice of custom eval_set: %s' % eval_set)
 
+    @unittest.skip
     def test_delta_gt(self,
                       eval_set: str = 'mini_val',
                       render_curves: bool = False):

--- a/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
@@ -3,9 +3,9 @@
 
 import json
 import os
-import sys
 import random
 import shutil
+import sys
 import unittest
 from typing import Dict, Optional, Any
 
@@ -13,11 +13,11 @@ import numpy as np
 from tqdm import tqdm
 
 from nuscenes import NuScenes
-from nuscenes.utils.splits import create_splits_scenes
 from nuscenes.eval.common.config import config_factory
+from nuscenes.eval.tracking.constants import TRACKING_NAMES
 from nuscenes.eval.tracking.evaluate import TrackingEval
 from nuscenes.eval.tracking.utils import category_to_tracking_name
-from nuscenes.eval.tracking.constants import TRACKING_NAMES
+from nuscenes.utils.splits import create_splits_scenes
 
 
 class TestMain(unittest.TestCase):

--- a/python-sdk/nuscenes/eval/tracking/utils.py
+++ b/python-sdk/nuscenes/eval/tracking/utils.py
@@ -1,11 +1,11 @@
 # nuScenes dev-kit.
 # Code written by Holger Caesar, 2019.
 
-from typing import Optional, Dict
 import warnings
+from typing import Optional, Dict
 
-import numpy as np
 import motmetrics
+import numpy as np
 from motmetrics.metrics import MetricsHost
 
 from nuscenes.eval.tracking.data_classes import TrackingMetrics

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -3,25 +3,25 @@
 # + Map mask by Kiwoo Shin, 2019.
 # + Methods operating on NuScenesMap and NuScenes by Holger Caesar, 2019.
 
-import os
 import json
+import os
 import random
 from typing import Dict, List, Tuple, Optional, Union
 
+import cv2
 import descartes
-from tqdm import tqdm
-import numpy as np
-import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
-from matplotlib.patches import Rectangle, Arrow
+import matplotlib.pyplot as plt
+import numpy as np
+from PIL import Image
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle, Arrow
 from mpl_toolkits.axes_grid1.inset_locator import mark_inset
-from PIL import Image
-from shapely.geometry import Polygon, MultiPolygon, LineString, Point, box
-from shapely import affinity
-import cv2
 from pyquaternion import Quaternion
+from shapely import affinity
+from shapely.geometry import Polygon, MultiPolygon, LineString, Point, box
+from tqdm import tqdm
 
 from nuscenes.nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import view_points

--- a/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
+++ b/python-sdk/nuscenes/scripts/export_2d_annotations_as_json.py
@@ -10,19 +10,19 @@ Note: Projecting tight 3d boxes to 2d generally leads to non-tight boxes.
       cameras cannot.
 """
 
-from nuscenes.nuscenes import NuScenes
-from nuscenes.utils.geometry_utils import view_points
+import argparse
+import json
+import os
+from collections import OrderedDict
+from typing import List, Tuple, Union
 
 import numpy as np
-import json
-import argparse
-import os
-
-from typing import List, Tuple, Union
 from pyquaternion.quaternion import Quaternion
-from collections import OrderedDict
-from tqdm import tqdm
 from shapely.geometry import MultiPoint, box
+from tqdm import tqdm
+
+from nuscenes.nuscenes import NuScenes
+from nuscenes.utils.geometry_utils import view_points
 
 
 def post_process_coords(corner_coords: List,

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -35,22 +35,22 @@ To work with the original KITTI dataset, use these parameters:
 
 See https://www.nuscenes.org/object-detection for more information on the nuScenes result format.
 """
-import os
 import json
+import os
 from typing import List, Dict, Any
 
-from pyquaternion import Quaternion
-import numpy as np
 import fire
-from PIL import Image
 import matplotlib.pyplot as plt
+import numpy as np
+from PIL import Image
+from pyquaternion import Quaternion
 
-from nuscenes.nuscenes import NuScenes
-from nuscenes.utils.geometry_utils import BoxVisibility, transform_matrix
-from nuscenes.utils.data_classes import LidarPointCloud, Box
-from nuscenes.utils.splits import create_splits_logs
-from nuscenes.utils.kitti import KittiDB
 from nuscenes.eval.detection.utils import category_to_detection_name
+from nuscenes.nuscenes import NuScenes
+from nuscenes.utils.data_classes import LidarPointCloud, Box
+from nuscenes.utils.geometry_utils import BoxVisibility, transform_matrix
+from nuscenes.utils.kitti import KittiDB
+from nuscenes.utils.splits import create_splits_logs
 
 
 class KittiConverter:

--- a/python-sdk/nuscenes/utils/data_classes.py
+++ b/python-sdk/nuscenes/utils/data_classes.py
@@ -1,12 +1,12 @@
 # nuScenes dev-kit.
 # Code written by Oscar Beijbom, 2018.
 
+import copy
 import os.path as osp
 import struct
 from abc import ABC, abstractmethod
 from functools import reduce
 from typing import Tuple, List, Dict
-import copy
 
 import cv2
 import numpy as np

--- a/python-sdk/nuscenes/utils/kitti.py
+++ b/python-sdk/nuscenes/utils/kitti.py
@@ -11,9 +11,9 @@ from PIL import Image
 from matplotlib.axes import Axes
 from pyquaternion import Quaternion
 
-from nuscenes.utils.geometry_utils import box_in_image, BoxVisibility, view_points
-from nuscenes.utils.data_classes import Box, LidarPointCloud
 from nuscenes.nuscenes import NuScenesExplorer
+from nuscenes.utils.data_classes import Box, LidarPointCloud
+from nuscenes.utils.geometry_utils import box_in_image, BoxVisibility, view_points
 
 
 class KittiDB:


### PR DESCRIPTION
This PR disables the slow unit tests from the tracking eval code (>100s runtime). This reduces the overall unit test runtime to 6s. Furthermore we rearrange all imports according to PEP 8.