### PR TITLE
Fix bug where points close to ego vehicle were filtered after transformation

### DIFF
--- a/python-sdk/nuscenes/utils/data_classes.py
+++ b/python-sdk/nuscenes/utils/data_classes.py
@@ -95,8 +95,9 @@ class PointCloud(ABC):
         sample_data_token = sample_rec['data'][chan]
         current_sd_rec = nusc.get('sample_data', sample_data_token)
         for _ in range(nsweeps):
-            # Load up the pointcloud.
+            # Load up the pointcloud and remove points close to the sensor.
             current_pc = cls.from_file(osp.join(nusc.dataroot, current_sd_rec['filename']))
+            current_pc.remove_close(min_distance)
 
             # Get past pose.
             current_pose_rec = nusc.get('ego_pose', current_sd_rec['ego_pose_token'])
@@ -112,8 +113,7 @@ class PointCloud(ABC):
             trans_matrix = reduce(np.dot, [ref_from_car, car_from_global, global_from_car, car_from_current])
             current_pc.transform(trans_matrix)
 
-            # Remove close points and add timevector.
-            current_pc.remove_close(min_distance)
+            # Add time vector which can be used as a temporal feature.
             time_lag = ref_time - 1e-6 * current_sd_rec['timestamp']  # Positive difference.
             times = time_lag * np.ones((1, current_pc.nbr_points()))
             all_times = np.hstack((all_times, times))


### PR DESCRIPTION
This PR addresses issue https://github.com/nutonomy/nuscenes-devkit/issues/287. When aggregating multiple lidar sweeps, we first transform them to the reference frame, then remove the points close to the origin. The correct order is to remove the close points in the current sensor frame before moving them to the sensor frame at a different timestamp.

The difference can be seen below.
Before:
![40 sweeps before](https://user-images.githubusercontent.com/39502217/73515287-c061ad80-442f-11ea-87e3-d80263a6f15e.png)
After:
![40 sweeps after](https://user-images.githubusercontent.com/39502217/73515288-c192da80-442f-11ea-8769-e97e67dc4823.png)
