### PR TITLE
Add an option to disable all radar filters

### DIFF
--- a/python-sdk/nuscenes/utils/data_classes.py
+++ b/python-sdk/nuscenes/utils/data_classes.py
@@ -263,6 +263,27 @@ class RadarPointCloud(PointCloud):
     dynprop_states = range(7)  # type: List[int] # Use [0, 2, 6] for moving objects only.
     ambig_states = [3]  # type: List[int]
 
+    @classmethod
+    def disable_filters(cls) -> None:
+        """
+        Disable all radar filter settings.
+        Use this method to plot all radar returns.
+        Note that this method affects the global settings.
+        """
+        cls.invalid_states = list(range(18))
+        cls.dynprop_states = list(range(8))
+        cls.ambig_states = list(range(5))
+
+    @classmethod
+    def default_filters(cls) -> None:
+        """
+        Set the defaults for all radar filter settings.
+        Note that this method affects the global settings.
+        """
+        cls.invalid_states = [0]
+        cls.dynprop_states = range(7)
+        cls.ambig_states = [3]
+
     @staticmethod
     def nbr_dims() -> int:
         """

--- a/python-sdk/tutorial.ipynb
+++ b/python-sdk/tutorial.ipynb
@@ -1159,7 +1159,26 @@
    "outputs": [],
    "source": [
     "nusc.render_sample_data(my_sample['data']['LIDAR_TOP'], nsweeps=5, underlay_map=True)\n",
-    "nusc.render_sample_data(my_sample['data']['RADAR_FRONT_RIGHT'], nsweeps=5, underlay_map=True)"
+    "nusc.render_sample_data(my_sample['data']['RADAR_FRONT'], nsweeps=5, underlay_map=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the radar plot above we only see very confident radar returns from two vehicles. This is due to the filter settings defined in the file `nuscenes/utils/data_classes.py`. If instead we want to disable all filters and render all returns, we can use the `disable_filters()` function. This returns a denser point cloud, but with many returns from background objects. To return to the default settings, simply call `default_filters()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nuscenes.utils.data_classes import RadarPointCloud\n",
+    "RadarPointCloud.disable_filters()\n",
+    "nusc.render_sample_data(my_sample['data']['RADAR_FRONT'], nsweeps=5, underlay_map=True)\n",
+    "RadarPointCloud.default_filters()"
    ]
   },
   {
@@ -1261,7 +1280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This simple PR adds a convenient function to disable all radar filters. This means that all radar returns (even ambiguous ones) are rendered. We also added an example to the tutorial.