### PR TITLE
Mtp baseline

### DIFF
--- a/python-sdk/nuscenes/eval/predict/baseline_model_inference.py
+++ b/python-sdk/nuscenes/eval/predict/baseline_model_inference.py
@@ -7,9 +7,9 @@ import os
 
 from nuscenes import NuScenes
 from nuscenes.eval.common.config import config_factory
+from nuscenes.eval.predict.splits import get_prediction_challenge_split
 from nuscenes.predict import PredictHelper
 from nuscenes.predict.models import ConstantVelocityHeading, PhysicsOracle
-from nuscenes.eval.predict.splits import get_prediction_challenge_split
 
 
 def main(version: str, data_root: str,

--- a/python-sdk/nuscenes/eval/predict/config.py
+++ b/python-sdk/nuscenes/eval/predict/config.py
@@ -10,9 +10,11 @@ class PredictionConfig:
 
     def __init__(self,
                  metrics: List[Metric],
-                 seconds: int = 6):
+                 seconds: int = 6,
+                 frequency: int = 2):
         self.metrics = metrics
         self.seconds = seconds
+        self.frequency = 2
 
     def serialize(self) -> Dict[str, Any]:
         """ Serialize instance into json-friendly format. """

--- a/python-sdk/nuscenes/eval/predict/config.py
+++ b/python-sdk/nuscenes/eval/predict/config.py
@@ -6,7 +6,13 @@ from nuscenes.eval.predict.metrics import Metric, DeserializeMetric
 
 
 class PredictionConfig:
-    """ Data class that specifies the prediction evaluation settings. """
+    """
+    Data class that specifies the prediction evaluation settings.
+    Intialized with:
+    metrics: List of nuscenes.eval.predict.metric.Metric objects
+    seconds: Number of seconds to predict for each agent
+    frequency: Rate at which prediction is made, in Hz
+    """
 
     def __init__(self,
                  metrics: List[Metric],
@@ -14,7 +20,7 @@ class PredictionConfig:
                  frequency: int = 2):
         self.metrics = metrics
         self.seconds = seconds
-        self.frequency = 2
+        self.frequency = frequency # Hz
 
     def serialize(self) -> Dict[str, Any]:
         """ Serialize instance into json-friendly format. """

--- a/python-sdk/nuscenes/eval/predict/config.py
+++ b/python-sdk/nuscenes/eval/predict/config.py
@@ -9,9 +9,9 @@ class PredictionConfig:
     """
     Data class that specifies the prediction evaluation settings.
     Intialized with:
-    metrics: List of nuscenes.eval.predict.metric.Metric objects
-    seconds: Number of seconds to predict for each agent
-    frequency: Rate at which prediction is made, in Hz
+    metrics: List of nuscenes.eval.predict.metric.Metric objects.
+    seconds: Number of seconds to predict for each agent.
+    frequency: Rate at which prediction is made, in Hz.
     """
 
     def __init__(self,
@@ -20,7 +20,7 @@ class PredictionConfig:
                  frequency: int = 2):
         self.metrics = metrics
         self.seconds = seconds
-        self.frequency = frequency # Hz
+        self.frequency = frequency  # Hz
 
     def serialize(self) -> Dict[str, Any]:
         """ Serialize instance into json-friendly format. """

--- a/python-sdk/nuscenes/eval/predict/do_inference.py
+++ b/python-sdk/nuscenes/eval/predict/do_inference.py
@@ -9,9 +9,9 @@ from typing import List
 from nuscenes import NuScenes
 from nuscenes.eval.common.config import config_factory
 from nuscenes.eval.predict.data_classes import Prediction
+from nuscenes.eval.predict.splits import get_prediction_challenge_split
 from nuscenes.predict import PredictHelper
 from nuscenes.predict.models import ConstantVelocityHeading
-from nuscenes.eval.predict.splits import get_prediction_challenge_split
 
 
 def do_inference_for_submission(helper: PredictHelper,

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -166,7 +166,7 @@ class MTPLoss:
 
     def __init__(self,
                  num_modes: int,
-                 regression_loss_weight: float,
+                 regression_loss_weight: float = 1.,
                  angle_threshold_degrees: float = 5.):
         """
         Inits MTP loss

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -19,13 +19,13 @@ from torchvision.models import (mobilenet_v2, resnet18, resnet34, resnet50,
 from nuscenes.eval.predict.config import PredictionConfig
 
 
-def trim_network_at_index(network: nn.Module, index: int) -> nn.Module:
+def trim_network_at_index(network: nn.Module, index: int = -1) -> nn.Module:
     """
     Returns a new network with all layers up to index from the back.
     :param network: Module to trim
     :param index: Where to trim the network. Counted from the last layer.
     """
-    return nn.Sequential(*list(network.children())[:-index])
+    return nn.Sequential(*list(network.children())[:index])
 
 RESNET_VERSION_TO_MODEL = {'resnet18': resnet18, 'resnet34': resnet34,
                            'resnet50': resnet50, 'resnet101': resnet101,

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -288,7 +288,7 @@ class MTPLoss:
 
     def __call__(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
 
-        batch_losses = torch.ones(predictions.shape[0], device=predictions.device).requires_grad_(True)
+        batch_losses = torch.Tensor(device=predictions.device).requires_grad_(True)
         trajectories, modes = self._get_trajectory_and_modes(predictions)
 
         for batch_idx in range(predictions.shape[0]):
@@ -302,7 +302,7 @@ class MTPLoss:
 
             best_mode_trajectory = trajectories[batch_idx, best_mode, :].unsqueeze(0)
 
-            regression_loss = f.smooth_l1_loss(best_mode_trajectory, targets[batch_idx].unsqueeze(0))
+            regression_loss = f.smooth_l1_loss(best_mode_trajectory, targets[batch_idx])
 
             mode_probabilities = modes[batch_idx].unsqueeze(0)
             best_mode_target = torch.tensor([best_mode], device=predictions.device)
@@ -310,7 +310,7 @@ class MTPLoss:
 
             loss = classification_loss + self.regression_loss_weight * regression_loss
 
-            batch_losses[batch_idx] = loss
+            batch_losses = torch.cat((batch_losses, loss.unsqueeze(0)), 0)
 
         avg_loss = torch.mean(batch_losses)
 

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -3,7 +3,7 @@
 
 """
 Implementation of Multiple-Trajectory Prediction (MTP) model,
-based on  https://arxiv.org/pdf/1809.10732.pdf.
+based on https://arxiv.org/pdf/1809.10732.pdf.
 """
 
 import math
@@ -16,20 +16,20 @@ from torch.nn import functional as f
 from torchvision.models import (mobilenet_v2, resnet18, resnet34, resnet50,
                                 resnet101, resnet152)
 
-from nuscenes.eval.predict.config import PredictionConfig
-
 
 def trim_network_at_index(network: nn.Module, index: int = -1) -> nn.Module:
     """
     Returns a new network with all layers up to index from the back.
-    :param network: Module to trim
+    :param network: Module to trim.
     :param index: Where to trim the network. Counted from the last layer.
     """
     return nn.Sequential(*list(network.children())[:index])
 
+
 RESNET_VERSION_TO_MODEL = {'resnet18': resnet18, 'resnet34': resnet34,
                            'resnet50': resnet50, 'resnet101': resnet101,
                            'resnet152': resnet152}
+
 
 class ResNetBackbone(nn.Module):
     """
@@ -41,7 +41,7 @@ class ResNetBackbone(nn.Module):
     def __init__(self, version: str):
         """
         Inits ResNetBackbone
-        :param vesion: resnet version to use.
+        :param version: resnet version to use.
         """
         super().__init__()
 
@@ -60,6 +60,7 @@ class ResNetBackbone(nn.Module):
         """
         backbone_features = self.backbone(input_tensor)
         return torch.flatten(backbone_features, start_dim=1)
+
 
 class MobileNetBackbone(nn.Module):
     """
@@ -83,16 +84,16 @@ class MobileNetBackbone(nn.Module):
     def forward(self, input_tensor):
         """
         Outputs features after last convolution.
-        :param input_tensor:  Shape [batch_size, n_channels, length, width]
+        :param input_tensor:  Shape [batch_size, n_channels, length, width].
         :return: Tensor of shape [batch_size, n_convolution_filters]. For mobilenet_v2,
-            the shape is [batch_size, 1280]
+            the shape is [batch_size, 1280].
         """
         backbone_features = self.backbone(input_tensor)
         return backbone_features.mean([2, 3])
 
 
 class MTP(nn.Module):
-    """Implements the MTP network."""
+    """ Implements the MTP network. """
 
     def __init__(self, backbone: nn.Module, num_modes: int,
                  seconds: float = 6, frequency_in_hz: float = 2,
@@ -103,8 +104,8 @@ class MTP(nn.Module):
         :param num_modes: Number of predicted paths to estimate for each agent.
         :param seconds: Number of seconds into the future to predict.
             Default for the challenge is 6.
-        :param frequency: Frequency between timesteps in the prediction (in HZ).
-            Highest frequency is nuScenes is 2 hz.
+        :param frequency_in_hz: Frequency between timesteps in the prediction (in Hz).
+            Highest frequency is nuScenes is 2 Hz.
         :param n_hidden_layers: Size of fully connected layer after the CNN
             backbone processes the image.
         :param input_shape: Shape of the input expected by the network.
@@ -127,7 +128,7 @@ class MTP(nn.Module):
         self.fc2 = nn.Linear(n_hidden_layers, int(num_modes * predictions_per_mode + num_modes))
 
     def _calculate_backbone_feature_dim(self, input_shape: Tuple[int, int, int]) -> int:
-        """Helper to calculate the shape of the fully-connected regression layer."""
+        """ Helper to calculate the shape of the fully-connected regression layer. """
         tensor = torch.ones(1, *input_shape)
         output_feat = self.backbone.forward(tensor)
         return output_feat.shape[-1]
@@ -144,9 +145,9 @@ class MTP(nn.Module):
 
         predictions = self.fc2(self.fc1(features))
 
-        # Normalize the probabilities to sum to 1 for inference
+        # Normalize the probabilities to sum to 1 for inference.
         mode_probabilities = predictions[:, -self.num_modes:].clone()
-        if self.training is False:
+        if not self.training:
             mode_probabilities = f.softmax(mode_probabilities, dim=-1)
 
         predictions = predictions[:, :-self.num_modes]
@@ -159,7 +160,9 @@ class MTPLoss:
     Computes the loss for the MTP model.
     """
 
-    def __init__(self, num_modes: int, regression_loss_weight: float,
+    def __init__(self,
+                 num_modes: int,
+                 regression_loss_weight: float,
                  angle_threshold_degrees: float = 5.):
         """
         Inits MTP loss
@@ -170,7 +173,7 @@ class MTPLoss:
             and the ground to consider it a match.
         """
         self.num_modes = num_modes
-        self.num_location_coordinates_predicted = 2 # We predict x, y coordinates at each timestep
+        self.num_location_coordinates_predicted = 2  # We predict x, y coordinates at each timestep.
         self.regression_loss_weight = regression_loss_weight
         self.angle_threshold = angle_threshold_degrees
 
@@ -178,9 +181,9 @@ class MTPLoss:
                                   model_prediction: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Splits the predictions from the model into mode probabilities and trajectory.
-        :param model_prediction: Tensor of shape [batch_size, n_timesteps * n_modes * 2 + n_modes]
+        :param model_prediction: Tensor of shape [batch_size, n_timesteps * n_modes * 2 + n_modes].
         :return: Tuple of tensors. First item is the trajectories of shape [batch_size, n_modes, n_timesteps, 2].
-            Second item are the mode probabilities of shape [batch_size, num_modes]
+            Second item are the mode probabilities of shape [batch_size, num_modes].
         """
         mode_probabilities = model_prediction[:, -self.num_modes:].clone()
 
@@ -189,19 +192,20 @@ class MTPLoss:
 
         return trajectories_no_modes, mode_probabilities
 
-    def _angle_between(self, ref_traj: torch.Tensor,
+    def _angle_between(self,
+                       ref_traj: torch.Tensor,
                        traj_to_compare: torch.Tensor) -> float:
         """
         Computes the angle between the last points of the two trajectories.
         The resulting angle is in degrees and is an angle in the [0; 180) interval.
-        :param ref_traj: Tensor of shape [n_timesteps, 2]
-        :param traj_to_compare: Tensor of shape [n_timesteps, 2]
+        :param ref_traj: Tensor of shape [n_timesteps, 2].
+        :param traj_to_compare: Tensor of shape [n_timesteps, 2].
         """
 
         EPSILON = 1e-5
 
         if (ref_traj.ndim != 2 or traj_to_compare.ndim != 2 or
-            ref_traj.shape[1] != 2 or traj_to_compare.shape[1] != 2):
+                ref_traj.shape[1] != 2 or traj_to_compare.shape[1] != 2):
             raise ValueError('Both tensors should have shapes (-1, 2).')
 
         if torch.isnan(traj_to_compare[-1]).any() or torch.isnan(ref_traj[-1]).any():
@@ -227,20 +231,19 @@ class MTPLoss:
 
     def _compute_ave_l2_norms(self, tensor: torch.Tensor) -> float:
         """
-        Compute the average of l2 norms of each row in the tensor
-        :param tensor: Shape [1, n_timesteps, 2]
+        Compute the average of l2 norms of each row in the tensor.
+        :param tensor: Shape [1, n_timesteps, 2].
         """
         l2_norms = torch.norm(tensor, p=2, dim=2)
         avg_distance = torch.mean(l2_norms)
         return avg_distance
 
     def _compute_angles_from_ground_truth(self, target: torch.Tensor,
-                                          trajectories: torch.Tensor) -> List[float]:
+                                          trajectories: torch.Tensor) -> List[Tuple[float, int]]:
         """
-        Compute angle between the target trajectory (ground truth) and
-        the predicted trajectories.
-        :param target: Shape [1, n_timesteps, 2]
-        :param trajectories: Shape [n_modes, n_timesteps, 2
+        Compute angle between the target trajectory (ground truth) and the predicted trajectories.
+        :param target: Shape [1, n_timesteps, 2].
+        :param trajectories: Shape [n_modes, n_timesteps, 2].
         :return: List of angles.
         """
         angles_from_ground_truth = []

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -288,7 +288,7 @@ class MTPLoss:
 
     def __call__(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
 
-        batch_losses = torch.Tensor(device=predictions.device).requires_grad_(True)
+        batch_losses = torch.Tensor().requires_grad_(True).to(predictions.device)
         trajectories, modes = self._get_trajectory_and_modes(predictions)
 
         for batch_idx in range(predictions.shape[0]):

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -304,9 +304,6 @@ class MTPLoss:
 
             regression_loss = f.smooth_l1_loss(best_mode_trajectory, targets[batch_idx].unsqueeze(0))
 
-            if batch_idx == 15:
-                import pdb; pdb.set_trace()
-
             mode_probabilities = modes[batch_idx].unsqueeze(0)
             best_mode_target = torch.tensor([best_mode], device=predictions.device)
             classification_loss = f.cross_entropy(mode_probabilities, best_mode_target)

--- a/python-sdk/nuscenes/predict/models/mtp.py
+++ b/python-sdk/nuscenes/predict/models/mtp.py
@@ -1,0 +1,320 @@
+# nuScenes dev-kit.
+# Code written by Freddy Boulton, Elena Corina Grigore 2020.
+
+"""
+Implementation of Multiple-Trajectory Prediction (MTP) model,
+based on  https://arxiv.org/pdf/1809.10732.pdf.
+"""
+
+import math
+import random
+from typing import List, Tuple
+
+import torch
+from torch import nn
+from torch.nn import functional as f
+from torchvision.models import (mobilenet_v2, resnet18, resnet34, resnet50,
+                                resnet101, resnet152)
+
+from nuscenes.eval.predict.config import PredictionConfig
+
+
+def trim_network_at_index(network: nn.Module, index: int) -> nn.Module:
+    """
+    Returns a new network with all layers up to index from the back.
+    :param network: Module to trim
+    :param index: Where to trim the network. Counted from the last layer.
+    """
+    return nn.Sequential(*list(network.children())[:-1])
+
+RESNET_VERSION_TO_MODEL = {'resnet18': resnet18, 'resnet34': resnet34,
+                           'resnet50': resnet50, 'resnet101': resnet101,
+                           'resnet152': resnet152}
+
+class ResNetBackbone(nn.Module):
+    """
+    Outputs tensor after last convolution before the fully connected layer.
+
+    Allowed versions: resnet18, resnet34, resnet50, resnet101, resnet152.
+    """
+
+    def __init__(self, version: str):
+        """
+        Inits ResNetBackbone
+        :param vesion: resnet version to use.
+        """
+        super().__init__()
+
+        if version not in RESNET_VERSION_TO_MODEL:
+            raise ValueError(f'Parameter version must be one of {list(RESNET_VERSION_TO_MODEL.keys())}'
+                             f'. Received {version}.')
+
+        self.backbone = trim_network_at_index(RESNET_VERSION_TO_MODEL[version](), -1)
+
+    def forward(self, input_tensor):
+        """
+        Outputs features after last convolution.
+        :param input_tensor:  Shape [batch_size, n_channels, length, width]
+        :return: Tensor of shape [batch_size, n_convolution_filters]. For resnet50,
+            the shape is [batch_size, 2048]
+        """
+        backbone_features = self.backbone(input_tensor)
+        return torch.flatten(backbone_features, start_dim=1)
+
+class MobileNetBackbone(nn.Module):
+    """
+    Outputs tensor after last convolution before the fully connected layer.
+
+    Allowed versions: mobilenet_v2.
+    """
+
+    def __init__(self, version: str):
+        """
+        Inits MobileNetBackbone
+        :param version: mobilenet version to use.
+        """
+        super().__init__()
+
+        if version != 'mobilenet_v2':
+            raise NotImplementedError(f'Only mobilenet_v2 has been implemented. Received {version}.')
+
+        self.backbone = trim_network_at_index(mobilenet_v2(), -1)
+
+    def forward(self, input_tensor):
+        """
+        Outputs features after last convolution.
+        :param input_tensor:  Shape [batch_size, n_channels, length, width]
+        :return: Tensor of shape [batch_size, n_convolution_filters]. For mobilenet_v2,
+            the shape is [batch_size, 1280]
+        """
+        backbone_features = self.backbone(input_tensor)
+        return backbone_features.mean([2, 3])
+
+
+class MTP(nn.Module):
+    """Implements the MTP network."""
+
+    def __init__(self, backbone: nn.Module, num_modes: int,
+                 seconds: int = 6, frequency_in_hz: int = 2,
+                 n_hidden_layers: int = 4096, input_shape: Tuple[int, int, int] = (3, 500, 500)):
+        """
+        Inits the MTP network.
+        :param backbone: CNN Backbone to use.
+        :param num_modes: Number of predicted paths to estimate for each agent.
+        :param seconds: Number of seconds into the future to predict.
+            Default for the challenge is 6.
+        :param frequency: Frequency between timesteps in the prediction (in HZ).
+            Highest frequency is nuScenes is 2 hz.
+        :param n_hidden_layers: Size of fully connected layer after the CNN
+            backbone processes the image.
+        :param input_shape: Shape of the input expected by the network.
+            This is needed because the size of the fully connected layer after
+            the backbone depends on the backbone and its version.
+        """
+
+        super().__init__()
+
+        self.backbone = backbone
+        self.num_modes = num_modes
+        backbone_feature_dim = self._calculate_backbone_feature_dim(input_shape)
+        self.fc1 = nn.Linear(backbone_feature_dim + 3, n_hidden_layers)
+        predictions_per_mode = seconds * frequency_in_hz * 2
+
+        self.fc2 = nn.Linear(n_hidden_layers, int(num_modes * predictions_per_mode + num_modes))
+
+    def _calculate_backbone_feature_dim(self, input_shape: Tuple[int, int, int]):
+        """Helper to calculate the shape of the fully-connected regression layer."""
+        tensor = torch.ones(1, *input_shape)
+        output_feat = self.backbone.forward(tensor)
+        return output_feat.shape[-1]
+
+    def forward(self, image_tensor, agent_state_vector):
+        """
+        Forward pass of the model.
+        """
+
+        backbone_features = self.backbone(image_tensor)
+
+        features = torch.cat([backbone_features, agent_state_vector], axis=1)
+
+        predictions = self.fc2(self.fc1(features))
+
+        # Normalize the probabilities to sum to 1 for inference
+        mode_probabilities = predictions[:, -self.num_modes:].clone()
+        if self.training is False:
+            mode_probabilities = f.softmax(mode_probabilities, dim=-1)
+
+        predictions = predictions[:, :-self.num_modes]
+
+        return torch.cat((predictions, mode_probabilities), 1)
+
+
+class MTPLoss:
+    """
+    Computes the loss for the MTP model.
+    """
+
+    def __init__(self, num_modes, regression_loss_weight,
+                 angle_threshold_degrees: float = 5.):
+        """
+        Inits MTP loss
+        :param num_modes: How many modes are being predicted for each agent.
+        :param regression_loss_weight: Coefficient applied to the regression loss to
+            balance classification and regression performance.
+        :param angle_threshold_degrees: Minimum angle needed between a predicted trajectory
+            and the ground to consider it a match.
+        """
+        self.num_modes = num_modes
+        self.num_location_coordinates_predicted = 2 # We predict x, y coordinates at each timestep
+        self.regression_loss_weight = regression_loss_weight
+        self.angle_threshold = angle_threshold_degrees
+
+    def _get_trajectory_and_modes(self,
+                                  model_prediction: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Splits the predictions from the model into mode probabilities and trajectory.
+        :param model_prediction: Tensor of shape [batch_size, n_timesteps * n_modes * 2 + n_modes]
+        :return: Tuple of tensors. First item is the trajectories of shape [batch_size, n_modes, n_timesteps, 2].
+            Second item are the mode probabilities of shape [batch_size, num_modes]
+        """
+        mode_probabilities = model_prediction[:, -self.num_modes:].clone()
+
+        desired_shape = (model_prediction.shape[0], self.num_modes, -1, self.num_location_coordinates_predicted)
+        trajectories_no_modes = model_prediction[:, :-self.num_modes].clone().reshape(desired_shape)
+
+        return trajectories_no_modes, mode_probabilities
+
+    def _angle_between(self, ref_traj: torch.Tensor,
+                       traj_to_compare: torch.Tensor) -> float:
+        """
+        Computes the angle between the last points of the two trajectories.
+        The resulting angle is in degrees and is an angle in the [0; 180) interval.
+        :param ref_traj: Tensor of shape [n_timesteps, 2]
+        :param traj_to_compare: Tensor of shape [n_timesteps, 2]
+        """
+
+        EPSILON = 1e-5
+
+        if (ref_traj.ndim != 2 or traj_to_compare.ndim != 2 or
+            ref_traj.shape[1] != 2 or traj_to_compare.shape[1] != 2):
+            raise ValueError('Both tensors should have shapes (-1, 2).')
+
+        if torch.isnan(traj_to_compare[-1]).any() or torch.isnan(ref_traj[-1]).any():
+            return 180. - EPSILON
+
+        traj_norms_product = float(torch.norm(ref_traj[-1]) * torch.norm(traj_to_compare[-1]))
+
+        # If either of the vectors described in the docstring has norm 0, return 0 as the angle.
+        if math.isclose(traj_norms_product, 0):
+            return 0.
+
+        # We apply the max and min operations below to ensure there is no value
+        # returned for cos_angle that is greater than 1 or less than -1.
+        # This should never be the case, but the check is in place for cases where
+        # we might encounter numerical instability.
+        dot_product = float(ref_traj[-1].dot(traj_to_compare[-1]))
+        angle = math.degrees(math.acos(max(min(dot_product / traj_norms_product, 1), -1)))
+
+        if angle >= 180:
+            return angle - EPSILON
+
+        return angle
+
+    def _compute_ave_l2_norms(self, tensor: torch.Tensor) -> float:
+        """
+        Compute the average of l2 norms of each row in the tensor
+        :param tensor: Shape [1, n_timesteps, 2]
+        """
+        l2_norms = torch.norm(tensor, p=2, dim=2)
+        avg_distance = torch.mean(l2_norms)
+        return avg_distance
+
+    def _compute_angles_from_ground_truth(self, target, trajectories) -> List[float]:
+        """
+        Compute angle between the target trajectory (ground truth) and
+        the predicted trajectories.
+        :param target: Shape [1, n_timesteps, 2]
+        :param trajectories: Shape [n_modes, n_timesteps, 2
+        :return: List of angles.
+        """
+        angles_from_ground_truth = []
+        for mode, mode_trajectory in enumerate(trajectories):
+            # For each mode, we compute the angle between the last point of the predicted trajectory for that
+            # mode and the last point of the ground truth trajectory.
+            angle = self._angle_between(target[0], mode_trajectory)
+
+            angles_from_ground_truth.append((angle, mode))
+        return angles_from_ground_truth
+
+    def _compute_best_mode(self, angles_from_ground_truth, target, trajectories):
+        """
+        Finds the index of the best mode given the angles from the ground truth.
+        :param angles_from_ground_truth: List of angles
+        :param target: Shape [1, n_timesteps, 2]
+        :param trajectories: Shape [n_modes, n_timesteps, 2]
+        """
+
+        # We first sort the modes based on the angle to the ground truth (ascending order), and keep track of
+        # the index corresponding to the biggest angle that is still smaller than a threshold value.
+        angles_from_ground_truth = sorted(angles_from_ground_truth)
+        max_angle_below_thresh_idx = -1
+        for angle_idx, (angle, mode) in enumerate(angles_from_ground_truth):
+            if angle <= self.angle_threshold:
+                max_angle_below_thresh_idx = angle_idx
+            else:
+                break
+
+        # We choose the best mode at random IF there are no modes with an angle less than the threshold.
+        if max_angle_below_thresh_idx == -1:
+            best_mode = random.randint(0, self.num_modes - 1)
+
+        # We choose the best mode to be the one that provides the lowest ave of l2 norms between the
+        # predicted trajectory and the ground truth, taking into account only the modes with an angle
+        # less than the threshold IF there is at least one mode with an angle less than the threshold.
+        else:
+            # Out of the selected modes above, we choose the final best mode as that which returns the
+            # smallest ave of l2 norms between the predicted and ground truth trajectories.
+            distances_from_ground_truth = []
+
+            for angle, mode in angles_from_ground_truth[:max_angle_below_thresh_idx + 1]:
+                norm = self._compute_ave_l2_norms(target - trajectories[mode, :, :]).item()
+
+                distances_from_ground_truth.append((norm, mode))
+
+            distances_from_ground_truth = sorted(distances_from_ground_truth)
+            best_mode = distances_from_ground_truth[0][1]
+
+        return best_mode
+
+    def __call__(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+
+        batch_losses = torch.ones(predictions.shape[0], device=predictions.device).requires_grad_(True)
+        trajectories, modes = self._get_trajectory_and_modes(predictions)
+
+        for batch_idx in range(predictions.shape[0]):
+
+            angles = self._compute_angles_from_ground_truth(target=targets[batch_idx],
+                                                            trajectories=trajectories[batch_idx])
+
+            best_mode = self._compute_best_mode(angles,
+                                                target=targets[batch_idx],
+                                                trajectories=trajectories[batch_idx])
+
+            best_mode_trajectory = trajectories[batch_idx, best_mode, :].unsqueeze(0)
+
+            regression_loss = f.smooth_l1_loss(best_mode_trajectory, targets[batch_idx].unsqueeze(0))
+
+            if batch_idx == 15:
+                import pdb; pdb.set_trace()
+
+            mode_probabilities = modes[batch_idx].unsqueeze(0)
+            best_mode_target = torch.tensor([best_mode], device=predictions.device)
+            classification_loss = f.cross_entropy(mode_probabilities, best_mode_target)
+
+            loss = classification_loss + self.regression_loss_weight * regression_loss
+
+            batch_losses[batch_idx] = loss
+
+        avg_loss = torch.mean(batch_losses)
+
+        return avg_loss

--- a/python-sdk/nuscenes/predict/models/physics.py
+++ b/python-sdk/nuscenes/predict/models/physics.py
@@ -149,11 +149,6 @@ class Baseline(abc.ABC):
         pass
 
 
-def random_p():
-    a = np.random.random(25)
-    return np.exp(a) / np.exp(a).sum()
-
-
 class ConstantVelocityHeading(Baseline):
     """ Makes predictions according to constant velocity and heading model. """
 

--- a/python-sdk/nuscenes/predict/tests/run_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/run_mtp.py
@@ -1,8 +1,9 @@
 import argparse
-import torch
+
 import numpy as np
-from torch.utils.data import DataLoader, IterableDataset
+import torch
 import torch.optim as optim
+from torch.utils.data import DataLoader, IterableDataset
 
 from nuscenes.predict.models.mtp import ResNetBackbone, MTP, MTPLoss
 

--- a/python-sdk/nuscenes/predict/tests/run_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/run_mtp.py
@@ -6,6 +6,7 @@ import torch.optim as optim
 
 from nuscenes.predict.models.mtp import ResNetBackbone, MTP, MTPLoss
 
+
 class TestDataset(IterableDataset):
 
     def __init__(self, num_modes: int = 1):
@@ -15,7 +16,7 @@ class TestDataset(IterableDataset):
 
         while True:
             image = torch.zeros((3, 100, 100))
-            agent_state_vector = torch.ones((3))
+            agent_state_vector = torch.ones(3)
             ground_truth = torch.ones((1, 12, 2))
 
             if self.num_modes == 1:
@@ -33,7 +34,7 @@ class TestDataset(IterableDataset):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description='Run MTP to makesure it overfits on a single test case.')
+    parser = argparse.ArgumentParser(description='Run MTP to make sure it overfits on a single test case.')
     parser.add_argument('--num_modes', type=int, help='How many modes to learn.', default=1)
     parser.add_argument('--use_gpu', type=bool, help='Whether to use gpu', default=False)
     args = parser.parse_args()

--- a/python-sdk/nuscenes/predict/tests/run_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/run_mtp.py
@@ -48,6 +48,8 @@ if __name__ == "__main__":
 
     backbone = ResNetBackbone('resnet18')
     model = MTP(backbone, args.num_modes)
+    model = model.to(device)
+
     loss_function = MTPLoss(args.num_modes, 1, 5)
 
     current_loss = 10000
@@ -63,6 +65,10 @@ if __name__ == "__main__":
 
     for img, agent_state_vector, ground_truth in dataloader:
 
+        img = img.to(device)
+        agent_state_vector = agent_state_vector.to(device)
+        ground_truth = ground_truth.to(device)
+
         optimizer.zero_grad()
 
         prediction = model(img, agent_state_vector)
@@ -70,7 +76,7 @@ if __name__ == "__main__":
         loss.backward()
         optimizer.step()
 
-        current_loss = loss.detach().numpy()
+        current_loss = loss.cpu().detach().numpy()
 
         print(f"Current loss is {current_loss:.4f}")
         if np.allclose(current_loss, minimum_loss, atol=1e-4):

--- a/python-sdk/nuscenes/predict/tests/run_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/run_mtp.py
@@ -1,0 +1,81 @@
+import argparse
+import torch
+import numpy as np
+from torch.utils.data import DataLoader, IterableDataset
+import torch.optim as optim
+
+from nuscenes.predict.models.mtp import ResNetBackbone, MTP, MTPLoss
+
+class TestDataset(IterableDataset):
+
+    def __init__(self, num_modes: int = 1):
+        self.num_modes = num_modes
+
+    def __iter__(self,):
+
+        while True:
+            image = torch.zeros((3, 100, 100))
+            agent_state_vector = torch.ones((3))
+            ground_truth = torch.ones((1, 12, 2))
+
+            if self.num_modes == 1:
+                going_forward = True
+            else:
+                going_forward = np.random.rand() > 0.25
+
+            if going_forward:
+                ground_truth[:, :, 1] = torch.arange(0, 6, step=0.5)
+            else:
+                ground_truth[:, :, 1] = -torch.arange(0, 6, step=0.5)
+
+            yield image, agent_state_vector, ground_truth
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Run MTP to makesure it overfits on a single test case.')
+    parser.add_argument('--num_modes', type=int, help='How many modes to learn.', default=1)
+    parser.add_argument('--use_gpu', type=bool, help='Whether to use gpu', default=False)
+    args = parser.parse_args()
+
+    if args.use_gpu:
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    else:
+        device = torch.device('cpu')
+
+    dataset = TestDataset(args.num_modes)
+    dataloader = DataLoader(dataset, batch_size=16, num_workers=0)
+
+    backbone = ResNetBackbone('resnet18')
+    model = MTP(backbone, args.num_modes)
+    loss_function = MTPLoss(args.num_modes, 1, 5)
+
+    current_loss = 10000
+
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+
+    n_iter = 0
+
+    minimum_loss = 0
+
+    if args.num_modes == 2:
+        minimum_loss += 0.56234
+
+    for img, agent_state_vector, ground_truth in dataloader:
+
+        optimizer.zero_grad()
+
+        prediction = model(img, agent_state_vector)
+        loss = loss_function(prediction, ground_truth)
+        loss.backward()
+        optimizer.step()
+
+        current_loss = loss.detach().numpy()
+
+        print(f"Current loss is {current_loss:.4f}")
+        if np.allclose(current_loss, minimum_loss, atol=1e-4):
+            print(f"Achieved near-zero loss after {n_iter} iterations.")
+            break
+
+        n_iter += 1
+

--- a/python-sdk/nuscenes/predict/tests/run_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/run_mtp.py
@@ -1,3 +1,10 @@
+# nuScenes dev-kit.
+# Code written by Freddy Boulton, 2020.
+
+"""
+Regression test to see if MTP can overfit on a single example.
+"""
+
 import argparse
 
 import numpy as np
@@ -8,7 +15,13 @@ from torch.utils.data import DataLoader, IterableDataset
 from nuscenes.predict.models.mtp import ResNetBackbone, MTP, MTPLoss
 
 
-class TestDataset(IterableDataset):
+class Dataset(IterableDataset):
+    """
+    Implements an infinite dataset where the input data
+    is always the same and the target is a path going
+    forward with 75% probability, and going backward
+    with 25% probability.
+    """
 
     def __init__(self, num_modes: int = 1):
         self.num_modes = num_modes
@@ -45,7 +58,7 @@ if __name__ == "__main__":
     else:
         device = torch.device('cpu')
 
-    dataset = TestDataset(args.num_modes)
+    dataset = Dataset(args.num_modes)
     dataloader = DataLoader(dataset, batch_size=16, num_workers=0)
 
     backbone = ResNetBackbone('resnet18')
@@ -63,6 +76,12 @@ if __name__ == "__main__":
     minimum_loss = 0
 
     if args.num_modes == 2:
+
+        # We expect to see 75% going_forward and
+        # 25% going backward. So the minimum
+        # classification loss is expected to be
+        # 0.56234
+
         minimum_loss += 0.56234
 
     for img, agent_state_vector, ground_truth in dataloader:

--- a/python-sdk/nuscenes/predict/tests/test_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp.py
@@ -13,6 +13,9 @@ class TestBackBones(unittest.TestCase):
             n_convs = 2
         elif isinstance(model[4][0], Bottleneck):
             n_convs = 3
+        else:
+            raise ValueError("Backbone layer block not supported!")
+        
         return sum([len(model[i]) for i in range(4, 8)]) * n_convs + 2
 
     def test_resnet(self):

--- a/python-sdk/nuscenes/predict/tests/test_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp.py
@@ -1,6 +1,8 @@
 import unittest
+
 import torch
 from torchvision.models.resnet import BasicBlock, Bottleneck
+
 from nuscenes.predict.models import mtp
 
 

--- a/python-sdk/nuscenes/predict/tests/test_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp.py
@@ -3,6 +3,7 @@ import torch
 from torchvision.models.resnet import BasicBlock, Bottleneck
 from nuscenes.predict.models import mtp
 
+
 class TestBackBones(unittest.TestCase):
 
     def count_layers(self, model):
@@ -44,6 +45,7 @@ class TestBackBones(unittest.TestCase):
         tensor = torch.ones((1, 3, 100, 100))
 
         self.assertEqual(mobilenet(tensor).shape[1], 1280)
+
 
 class TestMTP(unittest.TestCase):
 

--- a/python-sdk/nuscenes/predict/tests/test_mtp.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp.py
@@ -1,0 +1,98 @@
+import unittest
+import torch
+from torchvision.models.resnet import BasicBlock, Bottleneck
+from nuscenes.predict.models import mtp
+
+class TestBackBones(unittest.TestCase):
+
+    def count_layers(self, model):
+        if isinstance(model[4][0], BasicBlock):
+            n_convs = 2
+        elif isinstance(model[4][0], Bottleneck):
+            n_convs = 3
+        return sum([len(model[i]) for i in range(4, 8)]) * n_convs + 2
+
+    def test_resnet(self):
+
+        rn_18 = mtp.ResNetBackbone('resnet18')
+        rn_34 = mtp.ResNetBackbone('resnet34')
+        rn_50 = mtp.ResNetBackbone('resnet50')
+        rn_101 = mtp.ResNetBackbone('resnet101')
+        rn_152 = mtp.ResNetBackbone('resnet152')
+
+        tensor = torch.ones((1, 3, 100, 100))
+
+        self.assertEqual(rn_18(tensor).shape[1], 512)
+        self.assertEqual(rn_34(tensor).shape[1], 512)
+        self.assertEqual(rn_50(tensor).shape[1], 2048)
+        self.assertEqual(rn_101(tensor).shape[1], 2048)
+        self.assertAlmostEqual(rn_152(tensor).shape[1], 2048)
+
+        self.assertEqual(self.count_layers(list(rn_18.backbone.children())), 18)
+        self.assertEqual(self.count_layers(list(rn_34.backbone.children())), 34)
+        self.assertEqual(self.count_layers(list(rn_50.backbone.children())), 50)
+        self.assertEqual(self.count_layers(list(rn_101.backbone.children())), 101)
+        self.assertEqual(self.count_layers(list(rn_152.backbone.children())), 152)
+
+        with self.assertRaises(ValueError):
+            mtp.ResNetBackbone('resnet51')
+
+    def test_mobilenet(self):
+
+        mobilenet = mtp.MobileNetBackbone('mobilenet_v2')
+
+        tensor = torch.ones((1, 3, 100, 100))
+
+        self.assertEqual(mobilenet(tensor).shape[1], 1280)
+
+class TestMTP(unittest.TestCase):
+
+    def setUp(self):
+        self.image = torch.ones((1, 3, 100, 100))
+        self.agent_state_vector = torch.ones((1, 3))
+        self.image_5 = torch.ones((5, 3, 100, 100))
+        self.agent_state_vector_5 = torch.ones((5, 3))
+
+    def _run(self, model):
+        pred = model(self.image, self.agent_state_vector)
+        pred_5 = model(self.image_5, self.agent_state_vector_5)
+
+        self.assertTupleEqual(pred.shape, (1, 75))
+        self.assertTupleEqual(pred_5.shape, (5, 75))
+
+        model.training = False
+        pred = model(self.image, self.agent_state_vector)
+        self.assertTrue(torch.allclose(pred[:, -3:].sum(axis=1), torch.ones(pred.shape[0])))
+
+    def test_works_with_resnet_18(self,):
+        rn_18 = mtp.ResNetBackbone('resnet18')
+        model = mtp.MTP(rn_18, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+    def test_works_with_resnet_34(self,):
+        rn_34 = mtp.ResNetBackbone('resnet34')
+        model = mtp.MTP(rn_34, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+    def test_works_with_resnet_50(self,):
+        rn_50 = mtp.ResNetBackbone('resnet50')
+        model = mtp.MTP(rn_50, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+    def test_works_with_resnet_101(self,):
+        rn_101 = mtp.ResNetBackbone('resnet101')
+        model = mtp.MTP(rn_101, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+    def test_works_with_resnet_152(self,):
+        rn_152 = mtp.ResNetBackbone('resnet152')
+        model = mtp.MTP(rn_152, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+    def test_works_with_mobilenet_v2(self,):
+        mobilenet = mtp.MobileNetBackbone('mobilenet_v2')
+        model = mtp.MTP(mobilenet, 3, 6, 2, input_shape=(3, 100, 100))
+        self._run(model)
+
+
+

--- a/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
@@ -8,6 +8,10 @@ from nuscenes.predict.models import mtp
 
 
 class TestMTPLoss(unittest.TestCase):
+    """
+    Test each component of MTPLoss as well as the
+    __call__ method.
+    """
 
     def test_get_trajectories_and_modes(self):
 
@@ -17,7 +21,7 @@ class TestMTPLoss(unittest.TestCase):
         xy_pred = torch.arange(60).view(1, -1).repeat(1, 5).view(-1, 60)
         mode_pred = torch.arange(5).view(1, -1)
 
-        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], axis=1)
+        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], dim=1)
         prediction_bs_2 = prediction_bs_1.repeat(2, 1)
 
         # Testing many modes with batch size 1.
@@ -33,7 +37,7 @@ class TestMTPLoss(unittest.TestCase):
         xy_pred = torch.arange(60).view(1, -1).repeat(1, 1).view(-1, 60)
         mode_pred = torch.arange(1).view(1, -1)
 
-        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], axis=1)
+        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], dim=1)
         prediction_bs_2 = prediction_bs_1.repeat(2, 1)
 
         # Testing one mode with batch size 1.
@@ -52,9 +56,6 @@ class TestMTPLoss(unittest.TestCase):
             traj = torch.zeros((12, 2))
             traj[-1] = torch.Tensor(last_point)
             return traj
-
-        reference = torch.zeros(12, 2)
-        trajectory = torch.zeros(12, 2)
 
         loss = mtp.MTPLoss(0, 0, 0)
 

--- a/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
@@ -1,8 +1,10 @@
 
-import unittest
-import torch
-from nuscenes.predict.models import mtp
 import math
+import unittest
+
+import torch
+
+from nuscenes.predict.models import mtp
 
 
 class TestMTPLoss(unittest.TestCase):
@@ -74,9 +76,9 @@ class TestMTPLoss(unittest.TestCase):
 
         # test angle is 90.
         self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 1]),
-                                                  make_trajectory([-1, 1])), 90., places=4)
+                                                   make_trajectory([-1, 1])), 90., places=4)
         self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 0]),
-                                                  make_trajectory([0, 1])), 90., places=4)
+                                                   make_trajectory([0, 1])), 90., places=4)
 
         # test angle is 180.
         self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 0]),

--- a/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
+++ b/python-sdk/nuscenes/predict/tests/test_mtp_loss.py
@@ -1,0 +1,168 @@
+
+import unittest
+import torch
+from nuscenes.predict.models import mtp
+import math
+
+class TestMTPLoss(unittest.TestCase):
+
+    def test_get_trajectories_and_modes(self,):
+
+        loss_n_modes_5 = mtp.MTPLoss(5, 0, 0)
+        loss_n_modes_1 = mtp.MTPLoss(1, 0, 0)
+
+        xy_pred = torch.arange(60).view(1, -1).repeat(1, 5).view(-1, 60)
+        mode_pred = torch.arange(5).view(1, -1)
+
+        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], axis=1)
+        prediction_bs_2 = prediction_bs_1.repeat(2, 1)
+
+        # Testing many modes with batch size 1
+        traj, modes = loss_n_modes_5._get_trajectory_and_modes(prediction_bs_1)
+        self.assertTrue(torch.allclose(traj, xy_pred.unsqueeze(0).reshape(1, 5, 30, 2)))
+        self.assertTrue(torch.allclose(modes, mode_pred))
+
+        # Testing many modes with batch size > 1
+        traj, modes = loss_n_modes_5._get_trajectory_and_modes(prediction_bs_2)
+        self.assertTrue(torch.allclose(traj, xy_pred.repeat(1, 2).unsqueeze(0).reshape(2, 5, 30, 2)))
+        self.assertTrue(torch.allclose(modes, mode_pred.repeat(2, 1)))
+
+        xy_pred = torch.arange(60).view(1, -1).repeat(1, 1).view(-1, 60)
+        mode_pred = torch.arange(1).view(1, -1)
+
+        prediction_bs_1 = torch.cat([xy_pred.reshape(1, -1), mode_pred], axis=1)
+        prediction_bs_2 = prediction_bs_1.repeat(2, 1)
+
+        # Testing one mode with batch size 1
+        traj, modes = loss_n_modes_1._get_trajectory_and_modes(prediction_bs_1)
+        self.assertTrue(torch.allclose(traj, xy_pred.unsqueeze(0).reshape(1, 1, 30, 2)))
+        self.assertTrue(torch.allclose(modes, mode_pred))
+
+        # Testing one mode with batch size > 1
+        traj, modes = loss_n_modes_1._get_trajectory_and_modes(prediction_bs_2)
+        self.assertTrue(torch.allclose(traj, xy_pred.repeat(1, 2).unsqueeze(0).reshape(2, 1, 30, 2)))
+        self.assertTrue(torch.allclose(modes, mode_pred.repeat(2, 1)))
+
+    def test_angle_between_trajectories(self,):
+
+        def make_trajectory(last_point):
+            traj = torch.zeros((12, 2))
+            traj[-1] = torch.Tensor(last_point)
+            return traj
+
+        reference = torch.zeros(12, 2)
+        trajectory = torch.zeros(12, 2)
+
+        loss = mtp.MTPLoss(0, 0, 0)
+
+        # test angle is 0
+        self.assertEqual(loss._angle_between(make_trajectory([0, 0]), make_trajectory([0, 0])), 0.)
+        self.assertEqual(loss._angle_between(make_trajectory([15, 15]), make_trajectory([15, 15])), 0.)
+
+        # test angle is 15
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 1]),
+                                                   make_trajectory([math.sqrt(3)/2, 0.5])), 15., places=4)
+
+        # test angle is 30
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 0]),
+                                                   make_trajectory([math.sqrt(3)/2, 0.5])), 30., places=4)
+
+        # test angle is 45
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 1]),
+                                                   make_trajectory([0, 1])), 45., places=4)
+
+        # test angle is 90
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 1]),
+                                                  make_trajectory([-1, 1])), 90., places=4)
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 0]),
+                                                  make_trajectory([0, 1])), 90., places=4)
+
+        # test angle is 180
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([1, 0]),
+                               make_trajectory([-1, 0])), 180., places=4)
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([0, 1]),
+                                                   make_trajectory([0, -1])), 180., places=4)
+        self.assertAlmostEqual(loss._angle_between(make_trajectory([3, 1]),
+                                                   make_trajectory([-3, -1])), 180., places=4)
+
+    def test_compute_best_mode_nothing_below_threshold(self):
+        angles = [(90, 0), (80, 1), (70, 2)]
+        target = None
+        traj = None
+
+        loss = mtp.MTPLoss(3, 0, 5)
+        self.assertTrue(loss._compute_best_mode(angles, target, traj) in {0, 1, 2})
+
+        loss = mtp.MTPLoss(3, 0, 65)
+        self.assertTrue(loss._compute_best_mode(angles, target, traj) in {0, 1, 2})
+
+    def test_compute_best_mode_only_one_below_threshold(self):
+        angles = [(30, 1), (3, 0), (25, 2)]
+
+        target = torch.ones((1, 6, 2))
+        trajectory = torch.zeros((3, 6, 2))
+
+        loss = mtp.MTPLoss(3, 0, 5)
+        self.assertEqual(loss._compute_best_mode(angles, target, trajectory), 0)
+
+    def test_compute_best_mode_multiple_below_threshold(self):
+        angles = [(2, 2), (4, 1), (10, 0)]
+        target = torch.ones((1, 6, 2))
+        trajectory = torch.zeros((3, 6, 2))
+        trajectory[1] = 1
+
+        loss = mtp.MTPLoss(3, 0, 5)
+        self.assertEqual(loss._compute_best_mode(angles, target, trajectory), 1)
+
+    def test_compute_best_mode_only_one_mode(self):
+        angles = [(25, 0)]
+        target = torch.ones((1, 6, 2))
+        trajectory = torch.zeros((1, 6, 2))
+
+        loss = mtp.MTPLoss(1, 0, 5)
+        self.assertEqual(loss._compute_best_mode(angles, target, trajectory), 0)
+
+        trajectory[0] = 1
+        self.assertEqual(loss._compute_best_mode(angles, target, trajectory), 0)
+
+
+    def test_call_method_perfect_regression(self):
+        targets = torch.zeros((16, 1, 30, 2))
+        targets[:, :, :, 1] = torch.arange(start=0, end=3, step=0.1)
+
+        predictions = torch.ones((16, 610))
+        predictions[:, 540:600] = targets[0, 0, :, :].reshape(-1, 60)
+        predictions[:, -10:] = 1/10
+
+        loss = mtp.MTPLoss(10, 1, angle_threshold_degrees=20)
+
+        # Since one mode exactly matches gt, loss should only be classification error
+        self.assertAlmostEqual(float(loss(predictions, targets).detach().numpy()),
+                               -math.log(1/10), places=4)
+
+        # Now the best mode differs by 1 from the ground truth
+        # Smooth l1 loss subtracts 0.5 from l1 norm if diff >= 1
+        predictions[:, 540:600] += 1
+        self.assertAlmostEqual(float(loss(predictions, targets).detach().numpy()),
+                               -math.log(1/10) + 0.5,
+                               places=4)
+
+        # In this case, one element has perfect regression, the others are off by 1
+        predictions[1, 540:600] -= 1
+        self.assertAlmostEqual(float(loss(predictions, targets).detach().numpy()),
+                               -math.log(1/10) + (15/16)*0.5,
+                               places=4)
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/python-sdk/nuscenes/tests/test_predict_helper.py
+++ b/python-sdk/nuscenes/tests/test_predict_helper.py
@@ -1,11 +1,14 @@
 # nuScenes dev-kit.
 # Code written by Freddy Boulton, 2020.
 
+import copy
 import unittest
 from typing import Dict, List, Any
-from nuscenes.predict import PredictHelper, convert_global_coords_to_local
+
 import numpy as np
-import copy
+
+from nuscenes.predict import PredictHelper, convert_global_coords_to_local
+
 
 class MockNuScenes:
     """Mocks the NuScenes API needed to test PredictHelper"""

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -12,4 +12,6 @@ pyquaternion>=0.9.5
 scikit-learn
 scipy
 Shapely
+torch==1.4.0
+torchvision==0.5.0
 tqdm


### PR DESCRIPTION
* Adds a baseline MTP model with Resnet, MobileNet backbones
* Converts models.py into a directory with physics.py and mtp.py
* Adds unit tests for mtp.py

How to test:
* Run unit tests `nosetests predict/tests` and `nosetests eval/predict/tests`
* The script `run_mtp.py` tests whether the mtp model can overfit on a single example (for 1 or two modes) with the cpu or gpu

@elenacorinagrigore Please verify the model implementation

@emwolff @holger-nutonomy your feedback is appreciated :smile: 