### PR TITLE
Fix bug in new version of setuptools

### DIFF
--- a/setup/setup.py
+++ b/setup/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires=requirements,
     packages=packages,
     package_dir={'': 'python-sdk'},
-    package_data={'': '*.json'},
+    package_data={'': ['*.json']},
     include_package_data=True,
     classifiers=[
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
This PR fixes a bug in the latest version of setuptools, where the file names inside `package_data` need to be an array. It only affects the creation of pip packages.