### PR TITLE
Tracking eval - Fix motmetrics version

### DIFF
--- a/python-sdk/nuscenes/eval/tracking/mot.py
+++ b/python-sdk/nuscenes/eval/tracking/mot.py
@@ -33,7 +33,6 @@ class MOTAccumulatorCustom(motmetrics.mot.MOTAccumulator):
             list of events where each event is a list containing
             'Type', 'OId', HId', 'D'
         """
-
         idx = pd.MultiIndex.from_tuples(indices, names=['FrameId', 'Event'])
         df = pd.DataFrame(events, index=idx, columns=['Type', 'OId', 'HId', 'D'])
         return df

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -3,7 +3,7 @@ descartes
 fire
 jupyter
 matplotlib
-motmetrics
+motmetrics<=1.1.3
 numpy
 opencv-python
 pandas>=0.24


### PR DESCRIPTION
Addresses #299. Major changes in the new motmetrics version `1.2.0` break our tracking eval code. To ensure that the results of our tracking challenge do not change, we fix the version number to be `<= 1.1.3`.