### PR TITLE
Get next roads function

### DIFF
--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -97,8 +97,8 @@ class NuScenesMap:
         else:
             self.version = '1.0'
         if self.version < '1.1':
-            print('Warning: You are using an outdated map version! Please go to https://www.nuscenes.org/download to '
-                  'download the latest map!')
+            raise Exception('Error: You are using an outdated map version! '
+                            'Please go to https://www.nuscenes.org/download to download the latest map!')
 
     def _load_layer(self, layer_name: str) -> List[dict]:
         """

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -220,15 +220,17 @@ class NuScenesMap:
     def render_layers(self,
                       layer_names: List[str],
                       alpha: float = 0.5,
-                      figsize: Tuple[int, int] = (15, 15)) -> Tuple[Figure, Axes]:
+                      figsize: Tuple[int, int] = (15, 15),
+                      tokens: List[str] = None) -> Tuple[Figure, Axes]:
         """
         Render a list of layer names.
         :param layer_names: A list of layer names.
         :param alpha: The opacity of each layer that gets rendered.
         :param figsize: Size of the whole figure.
+        :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         :return: The matplotlib figure and axes of the rendered layers.
         """
-        return self.explorer.render_layers(layer_names, alpha, figsize)
+        return self.explorer.render_layers(layer_names, alpha, figsize, tokens)
 
     def render_map_patch(self,
                          box_coords: Tuple[float, float, float, float],
@@ -434,9 +436,23 @@ class NuScenesMap:
         """
         return self.explorer.get_bounds(layer_name, token)
 
-    def get_next_road(self, x: float, y: float) -> Dict[str, List[str]]:
+    def render_next_roads(self,
+                          x: float,
+                          y: float,
+                          alpha: float = 0.5,
+                          figsize: Tuple[int, int] = (15, 15)) -> None:
         """
-        Get the next road layer(s) from a point of interest.
+        Renders the possible next roads from a point of interest.
+        :param x: x coordinate of the point of interest.
+        :param y: y coordinate of the point of interest.
+        :param alpha: The opacity of each layer that gets rendered.
+        :param figsize: Size of the whole figure.
+        """
+        self.explorer.render_next_roads(x, y, alpha, figsize)
+
+    def get_next_roads(self, x: float, y: float) -> Dict[str, List[str]]:
+        """
+        Get the possible next roads from a point of interest.
         Returns road_segment, road_block and lane.
         :param x: x coordinate of the point of interest.
         :param y: y coordinate of the point of interest.
@@ -742,12 +758,14 @@ class NuScenesMapExplorer:
     def render_layers(self,
                       layer_names: List[str],
                       alpha: float,
-                      figsize: Tuple[int, int]) -> Tuple[Figure, Axes]:
+                      figsize: Tuple[int, int],
+                      tokens: List[str] = None) -> Tuple[Figure, Axes]:
         """
         Render a list of layers.
         :param layer_names: A list of layer names.
         :param alpha: The opacity of each layer.
         :param figsize: Size of the whole figure.
+        :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         :return: The matplotlib figure and axes of the rendered layers.
         """
         fig = plt.figure(figsize=figsize)
@@ -759,7 +777,7 @@ class NuScenesMapExplorer:
         layer_names = list(set(layer_names))
 
         for layer_name in layer_names:
-            self._render_layer(ax, layer_name, alpha)
+            self._render_layer(ax, layer_name, alpha, tokens)
 
         ax.legend()
 
@@ -1075,6 +1093,33 @@ class NuScenesMapExplorer:
             plt.savefig(out_path, bbox_inches='tight', pad_inches=0)
 
         return map_poses
+
+    def render_next_roads(self,
+                          x: float,
+                          y: float,
+                          alpha: float = 0.5,
+                          figsize: Tuple[int, int] = (15, 15)) -> None:
+        """
+        Renders the possible next roads from a point of interest.
+        :param x: x coordinate of the point of interest.
+        :param y: y coordinate of the point of interest.
+        :param alpha: The opacity of each layer that gets rendered.
+        :param figsize: Size of the whole figure.
+        """
+        # Get next roads.
+        next_roads = self.map_api.get_next_roads(x, y)
+        layer_names = []
+        tokens = []
+        for layer_name, layer_tokens in next_roads.items():
+            if len(layer_tokens) > 0:
+                layer_names.append(layer_name)
+                tokens.extend(layer_tokens)
+
+        # Render them.
+        fig, ax = self.render_layers(layer_names, alpha, figsize, tokens)
+
+        # Render current location with an x.
+        ax.plot(x, y, 'x', markersize=12, color='red')
 
     @staticmethod
     def _clip_points_behind_camera(points, near_plane: float):
@@ -1416,32 +1461,36 @@ class NuScenesMapExplorer:
         elif mode == 'within':
             return np.all(cond)
 
-    def _render_layer(self, ax: Axes, layer_name: str, alpha: float) -> None:
+    def _render_layer(self, ax: Axes, layer_name: str, alpha: float, tokens: List[str] = None) -> None:
         """
         Wrapper method that renders individual layers on an axis.
         :param ax: The matplotlib axes where the layer will get rendered.
         :param layer_name: Name of the layer that we are interested in.
         :param alpha: The opacity of the layer to be rendered.
+        :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         """
         if layer_name in self.map_api.non_geometric_polygon_layers:
-            self._render_polygon_layer(ax, layer_name, alpha)
+            self._render_polygon_layer(ax, layer_name, alpha, tokens)
         elif layer_name in self.map_api.non_geometric_line_layers:
-            self._render_line_layer(ax, layer_name, alpha)
+            self._render_line_layer(ax, layer_name, alpha, tokens)
         else:
             raise ValueError("{} is not a valid layer".format(layer_name))
 
-    def _render_polygon_layer(self, ax: Axes, layer_name: str, alpha: float) -> None:
+    def _render_polygon_layer(self, ax: Axes, layer_name: str, alpha: float, tokens: List[str] = None) -> None:
         """
         Renders an individual non-geometric polygon layer on an axis.
         :param ax: The matplotlib axes where the layer will get rendered.
         :param layer_name: Name of the layer that we are interested in.
         :param alpha: The opacity of the layer to be rendered.
+        :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         """
         if layer_name not in self.map_api.non_geometric_polygon_layers:
             raise ValueError('{} is not a polygonal layer'.format(layer_name))
 
         first_time = True
         records = getattr(self.map_api, layer_name)
+        if tokens is not None:
+            records = [r for r in records if r['token'] in tokens]
         if layer_name == 'drivable_area':
             for record in records:
                 polygons = [self.map_api.extract_polygon(polygon_token) for polygon_token in record['polygon_tokens']]
@@ -1467,18 +1516,21 @@ class NuScenesMapExplorer:
                 ax.add_patch(descartes.PolygonPatch(polygon, fc=self.color_map[layer_name], alpha=alpha,
                                                     label=label))
 
-    def _render_line_layer(self, ax: Axes, layer_name: str, alpha: float) -> None:
+    def _render_line_layer(self, ax: Axes, layer_name: str, alpha: float, tokens: List[str] = None) -> None:
         """
         Renders an individual non-geometric line layer on an axis.
         :param ax: The matplotlib axes where the layer will get rendered.
         :param layer_name: Name of the layer that we are interested in.
         :param alpha: The opacity of the layer to be rendered.
+        :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         """
         if layer_name not in self.map_api.non_geometric_line_layers:
             raise ValueError("{} is not a line layer".format(layer_name))
 
         first_time = True
         records = getattr(self.map_api, layer_name)
+        if tokens is not None:
+            records = [r for r in records if r['token'] in tokens]
         for record in records:
             if first_time:
                 label = layer_name

--- a/python-sdk/nuscenes/map_expansion/map_demo.ipynb
+++ b/python-sdk/nuscenes/map_expansion/map_demo.ipynb
@@ -219,6 +219,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Navigation\n",
+    "We also provide functions for navigation around the road network. For this purpose, the road layers `lane`, `road_block` and `road_segment` are especially useful (see definitions below). The `get_next_roads(x, y)` function looks at the road layer at a particular point. It then retrieves the next road object in the direction of the `lane` or `road_block`. As `road_segments` do not have a direction (e.g. intersections), we return all possible next roads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 873\n",
+    "y = 1286\n",
+    "print('Road objects on selected point:', nusc_map.layers_on_point(x, y), '\\n')\n",
+    "print('Next road objects:', nusc_map.get_next_roads(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also visualize the next roads using the `render_next_roads(x, y)` function. We see that there are 3 adjacent roads to the intersection specified by (x, y)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nusc_map.render_next_roads(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Data Exploration"
    ]
   },


### PR DESCRIPTION
Modified version of https://github.com/nutonomy/nuscenes-devkit/pull/306. 
Lists all possible next roads for the current lane/road segment/road lane.
Additionally we provide a method to render the next roads.
Both functions have been added to the map tutorial.

**Note:** Using an outdated map now leads to an error, rather than a warning.

Below is an example:
```
import matplotlib.pyplot as plt
from nuscenes.map_expansion.map_api import NuScenesMap

nusc_map = NuScenesMap(dataroot='/data/sets/nuscenes', map_name='singapore-onenorth')
x = 876
y = 1284
print(nusc_map.layers_on_point(x, y))
nusc_map.render_next_roads(x, y)
```
Returns 
```
{'drivable_area': 'c3e28556-b711-4581-9970-b66166fb907d', 'road_segment': '57416e99-8919-4a28-985b-033a16938243', 'road_block': '', 'lane': '', 'ped_crossing': '', 'walkway': '', 'stop_line': '', 'carpark_area': ''}
```
and
![1](https://user-images.githubusercontent.com/39502217/75784670-87558980-5d9d-11ea-843a-4d9987ded989.png)
We can see that from an intersection the neighboring 3 lanes were rendered.
Let's move slightly NorthEast:
```
x = 883
y = 1286
print(nusc_map.layers_on_point(x, y))
nusc_map.render_next_roads(x, y)
```
![3](https://user-images.githubusercontent.com/39502217/75784871-d56a8d00-5d9d-11ea-9e1b-f8079caf68f8.png)
We can see that from the oncoming lane the intersection was rendered.
In comparison, the entire map looks like:
![2](https://user-images.githubusercontent.com/39502217/75784692-8e7c9780-5d9d-11ea-8259-410c262570ab.png)

