### PR TITLE
Removed firetruck from instructions

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -249,12 +249,6 @@ Bounding Box color convention in example images:
     ![](https://www.nuscenes.org/public/images/taxonomy_imgs/police_vehicle_4.png)
 
  [Top](#overview)
-# Firetruck 
-+ All types of firetrucks. 
-
-    ![](https://www.nuscenes.org/public/images/taxonomy_imgs/firetruck_1.jpg)
-
- [Top](#overview)
 ## Ambulance 
 + All types of ambulances. 
 


### PR DESCRIPTION
This PR removes the firetruck class from the instructions. This class was removed from nuScenes, as it had only a handful of annotations. Addresses #328.