### PR TITLE
CAN bus refactor

### DIFF
--- a/python-sdk/nuscenes/can_bus/can_bus_api.py
+++ b/python-sdk/nuscenes/can_bus/can_bus_api.py
@@ -61,14 +61,17 @@ class NuScenesCanBus:
         ]
         self.all_messages = self.can_messages + self.derived_messages
 
-    def print_can_message_stats(self,
+    def print_all_message_stats(self,
                                 scene_name: str) -> None:
         """
         Prints the meta stats for each CAN message type of a particular scene.
         :param scene_name: The name of the scene, e.g. scene-0001.
         """
+        all_messages = {}
         for message_name in self.can_messages:
-            self.print_message_stats(scene_name, message_name)
+            messages = self.get_messages(scene_name, 'meta')
+            all_messages[message_name] = messages
+        print(json.dumps(all_messages, indent=2))
 
     def print_message_stats(self,
                             scene_name: str,

--- a/python-sdk/nuscenes/can_bus/tutorial.ipynb
+++ b/python-sdk/nuscenes/can_bus/tutorial.ipynb
@@ -119,7 +119,7 @@
     "veh_speed = np.array([(m['utime'], m['vehicle_speed']) for m in veh_speed])\n",
     "\n",
     "# Convert to m/s.\n",
-    "radius = 0.328\n",
+    "radius = 0.305  # Known Zoe wheel radius in meters.\n",
     "circumference = 2 * np.pi * radius\n",
     "wheel_speed[:, 1] *= circumference / 60\n",
     "veh_speed[:, 1] *= 1 / 3.6\n",

--- a/python-sdk/nuscenes/can_bus/tutorial.ipynb
+++ b/python-sdk/nuscenes/can_bus/tutorial.ipynb
@@ -57,16 +57,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "message_name = 'steeranglefeedback'\n",
-    "nusc_can.get_messages(scene_name, message_name)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -82,6 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "message_name = 'steeranglefeedback'\n",
     "key_name = 'value'\n",
     "nusc_can.plot_message_data(scene_name, message_name, key_name)"
    ]
@@ -102,6 +93,53 @@
     "message_name = 'pose'\n",
     "key_name = 'accel'\n",
     "nusc_can.plot_message_data(scene_name, message_name, key_name, dimension=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also retrieve the raw data and compare the wheel speeds to the vehicle speeds. Here we convert the wheel speed from rounds per minute to m/s and the vehicle speed from km/h to m/s. We can see that there is a small offset between the speeds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Retrieve raw data.\n",
+    "wheel_speed = nusc_can.get_messages(scene_name, 'zoe_veh_info')\n",
+    "wheel_speed = np.array([(m['utime'], m['FL_wheel_speed']) for m in wheel_speed])\n",
+    "\n",
+    "veh_speed = nusc_can.get_messages(scene_name, 'vehicle_monitor')\n",
+    "veh_speed = np.array([(m['utime'], m['vehicle_speed']) for m in veh_speed])\n",
+    "\n",
+    "# Convert to m/s.\n",
+    "radius = 0.328\n",
+    "circumference = 2 * np.pi * radius\n",
+    "wheel_speed[:, 1] *= circumference / 60\n",
+    "veh_speed[:, 1] *= 1 / 3.6\n",
+    "\n",
+    "# Normalize time.\n",
+    "wheel_speed[:, 0] = (wheel_speed[:, 0] - wheel_speed[0, 0]) / 1e6\n",
+    "veh_speed[:, 0] = (veh_speed[:, 0] - veh_speed[0, 0]) / 1e6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(wheel_speed[:, 0], wheel_speed[:, 1])\n",
+    "plt.plot(veh_speed[:, 0], veh_speed[:, 1])\n",
+    "plt.xlabel('Time in s')\n",
+    "plt.ylabel('Speed in m/s')\n",
+    "plt.legend(['Wheel speed', 'Vehicle speed']);"
    ]
   },
   {

--- a/python-sdk/nuscenes/can_bus/tutorial.ipynb
+++ b/python-sdk/nuscenes/can_bus/tutorial.ipynb
@@ -53,7 +53,17 @@
    "outputs": [],
    "source": [
     "scene_name = 'scene-0001'\n",
-    "nusc_can.print_can_message_stats(scene_name)"
+    "nusc_can.print_all_message_stats(scene_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "message_name = 'steeranglefeedback'\n",
+    "nusc_can.get_messages(scene_name, message_name)"
    ]
   },
   {
@@ -72,7 +82,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nusc_can.plot_message_data(scene_name, 'steeranglefeedback', 'value')"
+    "key_name = 'value'\n",
+    "nusc_can.plot_message_data(scene_name, message_name, key_name)"
    ]
   },
   {
@@ -88,7 +99,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nusc_can.plot_message_data(scene_name, 'pose', 'accel', dimension=1)"
+    "message_name = 'pose'\n",
+    "key_name = 'accel'\n",
+    "nusc_can.plot_message_data(scene_name, message_name, key_name, dimension=1)"
    ]
   },
   {


### PR DESCRIPTION
This PR does the following:
- Rename and reorganize the `print_can_message_stats` function.
- Add more details to the tutorial, in particular render the vehicle speed vs. the wheel speed.