### PR TITLE
Relax pip package requirements

### DIFF
--- a/python-sdk/nuscenes/eval/prediction/README.md
+++ b/python-sdk/nuscenes/eval/prediction/README.md
@@ -1,5 +1,5 @@
 # nuScenes prediction task
-!![nuScenes Prediction logo](https://www.nuscenes.org/public/images/prediction.png)
+![nuScenes Prediction logo](https://www.nuscenes.org/public/images/prediction.png)
 
 ## Overview
 - [Introduction](#introduction)

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -7,11 +7,11 @@ motmetrics<=1.1.3
 numpy
 opencv-python
 pandas>=0.24
-Pillow
+Pillow<=6.2.1  # Latest Pillow is incompatible with current torchvision, https://github.com/pytorch/vision/issues/1712
 pyquaternion>=0.9.5
 scikit-learn
 scipy
 Shapely
-torch==1.4.0
-torchvision==0.5.0
+torch>=1.3.1
+torchvision>=0.4.2
 tqdm


### PR DESCRIPTION
This PR does the following:
- Relax the version requirements for torch and torchvision.
- Set a maximum pillow version as newer versions are not currently supported by torchvision.
- Merge in the changes from https://github.com/nutonomy/nuscenes-devkit/pull/339, as the torch l1 loss throws an exception (`RuntimeError: Expected object of scalar type Float but got scalar type Long for argument #2 'target' in call to _thnn_l1_loss_forward`) - **wait for that PR to merge first**.