### PR TITLE
Fix basic_tutorial name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please follow these steps to make yourself familiar with the nuScenes dataset:
 - Get the [nuscenes-devkit code](https://github.com/nutonomy/nuscenes-devkit).
 - Read the [online tutorial](https://www.nuscenes.org/tutorial) or run it yourself using:
 ```
-jupyter notebook $HOME/nuscenes-devkit/python-sdk/tutorials/nuscenes_basics.ipynb
+jupyter notebook $HOME/nuscenes-devkit/python-sdk/tutorials/nuscenes_basics_tutorial.ipynb
 ```
 - Read the [nuScenes paper](https://www.nuscenes.org/publications) for a detailed analysis of the dataset.
 - Run the [map expansion tutorial](https://github.com/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/map_expansion_tutorial.ipynb).


### PR DESCRIPTION
This PR fixes a link in the README that points to the nuScenes basics tutorial.