### PR TITLE
Automatically determine which lidarseg classes are present in a pointcloud projected onto an image

### DIFF
--- a/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
+++ b/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
@@ -165,3 +165,35 @@ def filter_colormap(colormap: np.array, classes_to_display: np.array) -> np.ndar
     colormap = np.concatenate((colormap, alpha.T), axis=1)
 
     return colormap
+
+
+def get_labels_in_coloring(color_legend: np.ndarray, coloring: np.ndarray) -> List:
+    """
+    Find the class labels which are present in a pointcloud which has been projected onto an image.
+    :param color_legend: A list of arrays in which each array corresponds to the RGB values of a class.
+    :param coloring: A list of arrays in which each array corresponds to the RGB values of a point in the portion of
+                     the pointcloud projected onto the image.
+    :return <List: n> List of class indices which are present in the image.
+    """
+
+    def __arreq_in_list(myarr, list_arrays) -> bool:
+        """
+        Check if an array is in a list of arrays.
+        :param: myarr: An array.
+        :param: list_arrays: A list of arrays.
+        :return <bool> Whether the given array is in the list of arrays.
+        """
+        # Credits: https://stackoverflow.com/questions/23979146/check-if-numpy-array-is-in-list-of-numpy-arrays
+        return next((True for elem in list_arrays if np.array_equal(elem, myarr)), False)
+
+    filter_lidarseg_labels = []
+
+    # Get only the distinct colors present in the pointcloud so that we will not need to compare each color in
+    # the color legend with every single point in the pointcloud later.
+    distinct_colors = set(tuple(c) for c in coloring)
+
+    for i, color in enumerate(color_legend):
+        if __arreq_in_list(color, distinct_colors):
+            filter_lidarseg_labels.append(i)
+
+    return filter_lidarseg_labels

--- a/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
+++ b/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
@@ -15,7 +15,7 @@ def get_stats(points_label: np.array, num_classes: int) -> List[int]:
     Get frequency of each label in a point cloud.
     :param num_classes: The number of classes.
     :param points_label: A numPy array which contains the labels of the point cloud; e.g. np.array([2, 1, 34, ..., 38])
-    :returns: An array which contains the counts of each label in the point cloud. The index of the point cloud
+    :return: An array which contains the counts of each label in the point cloud. The index of the point cloud
               corresponds to the index of the class label. E.g. [0, 2345, 12, 451] means that there are no points in
               class 0, there are 2345 points in class 1, there are 12 points in class 2 etc.
     """
@@ -148,7 +148,7 @@ def filter_colormap(colormap: np.array, classes_to_display: np.array) -> np.ndar
     of the labels to be display set to 1.0 and those to be hidden set to 0.0
     :param colormap: [n x 3] array where each row consist of the RGB values for the corresponding class index
     :param classes_to_display: An array of classes to display (e.g. [1, 8, 32]). The array need not be ordered.
-    :return (colormap <np.float: n, 4)>).
+    :return: (colormap <np.float: n, 4)>).
 
     colormap = np.array([[R1, G1, B1],             colormap = np.array([[1.0, 1.0, 1.0, 0.0],
                          [R2, G2, B2],   ------>                        [R2,  G2,  B2,  1.0],
@@ -167,33 +167,33 @@ def filter_colormap(colormap: np.array, classes_to_display: np.array) -> np.ndar
     return colormap
 
 
-def get_labels_in_coloring(color_legend: np.ndarray, coloring: np.ndarray) -> List:
+def get_labels_in_coloring(color_legend: np.ndarray, coloring: np.ndarray) -> List[int]:
     """
     Find the class labels which are present in a pointcloud which has been projected onto an image.
     :param color_legend: A list of arrays in which each array corresponds to the RGB values of a class.
     :param coloring: A list of arrays in which each array corresponds to the RGB values of a point in the portion of
                      the pointcloud projected onto the image.
-    :return <List: n> List of class indices which are present in the image.
+    :return: List of class indices which are present in the image.
     """
 
-    def __arreq_in_list(myarr, list_arrays) -> bool:
+    def _array_in_list(arr: List, list_arrays: List) -> bool:
         """
         Check if an array is in a list of arrays.
-        :param: myarr: An array.
+        :param: arr: An array.
         :param: list_arrays: A list of arrays.
-        :return <bool> Whether the given array is in the list of arrays.
+        :return: Whether the given array is in the list of arrays.
         """
         # Credits: https://stackoverflow.com/questions/23979146/check-if-numpy-array-is-in-list-of-numpy-arrays
-        return next((True for elem in list_arrays if np.array_equal(elem, myarr)), False)
+        return next((True for elem in list_arrays if np.array_equal(elem, arr)), False)
 
     filter_lidarseg_labels = []
 
     # Get only the distinct colors present in the pointcloud so that we will not need to compare each color in
     # the color legend with every single point in the pointcloud later.
-    distinct_colors = set(tuple(c) for c in coloring)
+    distinct_colors = list(set(tuple(c) for c in coloring))
 
     for i, color in enumerate(color_legend):
-        if __arreq_in_list(color, distinct_colors):
+        if _array_in_list(color, distinct_colors):
             filter_lidarseg_labels.append(i)
 
     return filter_lidarseg_labels

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -12,6 +12,7 @@ from typing import Tuple, List, Iterable
 
 import cv2
 import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
 import numpy as np
 import sklearn.metrics
 from PIL import Image
@@ -894,7 +895,6 @@ class NuScenesExplorer:
 
         # Produce a legend with the unique colors from the scatter.
         if pointsensor_channel == 'LIDAR_TOP' and show_lidarseg_labels and show_lidarseg_legend:
-            import matplotlib.patches as mpatches
             recs = []
             classes_final = []
             classes = [name for idx, name in sorted(self.nusc.lidarseg_idx2name_mapping.items())]

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -82,6 +82,11 @@ class NuScenes:
                 print('Loading nuScenes-lidarseg...')
 
             self.lidarseg = self.__load_table__('lidarseg')
+            num_lidarseg_recs = len(self.lidarseg)
+            num_bin_files = len([name for name in os.listdir(os.path.join(self.dataroot, 'lidarseg', self.version))
+                                 if name.endswith('.bin')])
+            assert num_lidarseg_recs == num_bin_files, \
+                'Error: There are {} .bin files but {} lidarseg records.'.format(num_bin_files, num_lidarseg_recs)
             self.table_names.append('lidarseg')
 
             lidarseg_categories = self.__load_table__('category_lidarseg')

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -910,8 +910,10 @@ class NuScenesExplorer:
                 # Create legend only for labels specified in the lidarseg filter.
                 if filter_lidarseg_labels is None or i in filter_lidarseg_labels:
                     recs.append(mpatches.Rectangle((0, 0), 1, 1, fc=color_legend[i]))
-                    classes_final.append(classes[i])
-            plt.legend(recs, classes_final, loc='lower left', ncol=3)
+
+                    # Truncate class names to only first 25 chars so that legend is not excessively long.
+                    classes_final.append(classes[i][:25])
+            plt.legend(recs, classes_final, loc='upper center', ncol=3)
 
         if out_path is not None:
             plt.savefig(out_path, bbox_inches='tight', pad_inches=0, dpi=200)


### PR DESCRIPTION
### This PR will:
- Add functionality to `render_pointcloud_in_image` to automatically determine which lidarseg classes are present in a pointcloud projected onto an image.

Previously, if the user does not specify a filter which contains the classes he / she wishes to see, and does the following with `show_lidarseg_legend=True`:
```
sample_token = '6dabc0fb1df045558f802246dd186b3f'

nusc.render_pointcloud_in_image(sample_token,
                                    pointsensor_channel='LIDAR_TOP',
                                    camera_channel='CAM_BACK',
                                    render_intensity=False,
                                    show_lidarseg_labels=True,
                                    render_if_no_points=False,
                                    show_lidarseg_legend=True,
                                    verbose=True)
```
Then the resulting visualization will be:
![before](https://user-images.githubusercontent.com/62535720/83865095-43856e00-a758-11ea-9725-b0b1778013a8.png)

This is ugly as the legend fills almost the entire image, and the user is no longer able to view the projected pointcloud. The user will then have to manually find out / guess which classes are present in order to apply a filter to see just those classes. This is quite inconvenient and troublesome from the perspective of the user's experience.

With this PR, `render_pointcloud_in_image` will automatically determine which lidarseg classes are present in a pointcloud projected onto an image and then show the legend only for those labels
![test222](https://user-images.githubusercontent.com/62535720/83992353-a0646c80-a982-11ea-96b1-b1a2daa86d5b.png)
