### PR TITLE
Improve aesthetics for render_scene_with_pointclouds_for_all_cameras

### DIFF
--- a/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
+++ b/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
@@ -124,7 +124,7 @@ def get_colormap() -> np.ndarray:
     return colormap
 
 
-def get_arbitrary_colormap(num_classes: int, random_seed: int = 2020) -> np.ndarray:
+def get_arbitrary_colormap(num_classes: int, random_seed: int = 93) -> np.ndarray:
     """
     Create an arbitrary RGB colormap. Note that the RGB values are normalized between 0 and 1, not 0 and 255.
     :param num_classes: Number of colors to create.

--- a/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
+++ b/python-sdk/nuscenes/lidarseg/lidarseg_utils.py
@@ -58,6 +58,9 @@ def plt_to_cv2(points: np.array, coloring: np.array, im, imsize: Tuple[int, int]
     ax = plt.Axes(fig, [0., 0., 1., 1.])
     fig.add_axes(ax)
 
+    ax.axis('off')
+    ax.margins(0, 0)
+
     ax.imshow(im)
     ax.scatter(points[0, :], points[1, :], c=coloring, s=5)
 

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1795,6 +1795,7 @@ class NuScenesExplorer:
                         key = cv2.waitKey()
 
                     if key == 27:  # if ESC is pressed, exit.
+                        plt.close('all')  # To prevent figures from accumulating in memory.
                         cv2.destroyAllWindows()
                         break
 

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1796,6 +1796,11 @@ class NuScenesExplorer:
 
                     if key == 27:  # if ESC is pressed, exit.
                         plt.close('all')  # To prevent figures from accumulating in memory.
+                        # If rendering is stopped halfway, save whatever has been rendered so far into a video
+                        # (if save_as_vid = True).
+                        if save_as_vid:
+                            out.write(mat)
+                            out.release()
                         cv2.destroyAllWindows()
                         break
 
@@ -1937,7 +1942,7 @@ class NuScenesExplorer:
                     if save_as_vid:
                         out.write(slate)
                         out.release()
-
+                    cv2.destroyAllWindows()
                     break
 
             plt.close('all')  # To prevent figures from accumulating in memory.

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1858,6 +1858,8 @@ class NuScenesExplorer:
             'CAM_BACK_RIGHT': (2 * imsize[0], imsize[1]),
         }
 
+        horizontal_flip = ['CAM_BACK_LEFT', 'CAM_BACK', 'CAM_BACK_RIGHT']  # Flip these for aesthetic reasons.
+
         window_name = '{} {labels_type} (Space to pause, ESC to exit)'.format(
             scene_record['name'], labels_type="(predictions)" if lidarseg_preds_folder else "")
         cv2.namedWindow(window_name)
@@ -1901,6 +1903,10 @@ class NuScenesExplorer:
                 if im is not None:
                     mat = plt_to_cv2(points, coloring, im, imsize)
 
+                    if camera_channel in horizontal_flip:
+                        # Flip image horizontally.
+                        mat = cv2.flip(mat, 1)
+
                     slate[layout[camera_channel][1]: layout[camera_channel][1] + imsize[1],
                     layout[camera_channel][0]:layout[camera_channel][0] + imsize[0], :] = mat
 
@@ -1912,7 +1918,12 @@ class NuScenesExplorer:
                     key = cv2.waitKey()
 
                 if key == 27:  # if ESC is pressed, exit.
-                    cv2.destroyAllWindows()
+                    # If rendering is stopped halfway, save whatever has been rendered so far into a video
+                    # (if save_as_vid = True).
+                    if save_as_vid:
+                        out.write(slate)
+                        out.release()
+
                     break
 
             plt.close('all')  # To prevent figures from accumulating in memory.

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1918,6 +1918,7 @@ class NuScenesExplorer:
                     key = cv2.waitKey()
 
                 if key == 27:  # if ESC is pressed, exit.
+                    plt.close('all')  # To prevent figures from accumulating in memory.
                     # If rendering is stopped halfway, save whatever has been rendered so far into a video
                     # (if save_as_vid = True).
                     if save_as_vid:

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1878,10 +1878,13 @@ class NuScenesExplorer:
 
         horizontal_flip = ['CAM_BACK_LEFT', 'CAM_BACK', 'CAM_BACK_RIGHT']  # Flip these for aesthetic reasons.
 
-        window_name = '{} {labels_type} (Space to pause, ESC to exit)'.format(
-            scene_record['name'], labels_type="(predictions)" if lidarseg_preds_folder else "")
-        cv2.namedWindow(window_name)
-        cv2.moveWindow(window_name, 0, 0)
+        if verbose:
+            window_name = '{} {labels_type} (Space to pause, ESC to exit)'.format(
+                scene_record['name'], labels_type="(predictions)" if lidarseg_preds_folder else "")
+            cv2.namedWindow(window_name)
+            cv2.moveWindow(window_name, 0, 0)
+        else:
+            window_name = None
 
         slate = np.ones((2 * imsize[1], 3 * imsize[0], 3), np.uint8)
 

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -49,6 +49,8 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.expanduser('~/Desktop/nuscenes-devkit/python-sdk'))\n",
     "from nuscenes import NuScenes\n",
     "\n",
     "nusc = NuScenes(version='v1.0-mini', dataroot='/data/sets/nuscenes', verbose=True)"
@@ -155,7 +157,7 @@
     "nusc.render_sample_data(sample_data_token,\n",
     "                        with_anns=False,\n",
     "                        show_lidarseg_labels=True,\n",
-    "                        filter_lidarseg_labels=[3, 4, 5])"
+    "                        filter_lidarseg_labels=[9, 14, 18])"
    ]
   },
   {
@@ -184,7 +186,7 @@
     "                                camera_channel='CAM_BACK',\n",
     "                                render_intensity=False,\n",
     "                                show_lidarseg_labels=True,\n",
-    "                                filter_lidarseg_labels=[3, 4, 5],\n",
+    "                                filter_lidarseg_labels=[9, 14, 18],\n",
     "                                show_lidarseg_legend=True,\n",
     "                                verbose=True)"
    ]
@@ -207,7 +209,7 @@
     "                                camera_channel='CAM_BACK',\n",
     "                                render_intensity=False,\n",
     "                                show_lidarseg_labels=True,\n",
-    "                                filter_lidarseg_labels=[30, 15],\n",
+    "                                filter_lidarseg_labels=[21, 11],\n",
     "                                show_lidarseg_legend=True,\n",
     "                                verbose=True,\n",
     "                                render_if_no_points=False)"
@@ -236,7 +238,7 @@
    "source": [
     "nusc.render_sample(my_sample['token'],\n",
     "                   show_lidarseg_labels=True,\n",
-    "                   filter_lidarseg_labels=[3, 4, 5],\n",
+    "                   filter_lidarseg_labels=[9, 14, 18],\n",
     "                   verbose=True)"
    ]
   },
@@ -282,7 +284,7 @@
     "# import os\n",
     "# nusc.render_camera_channel_with_pointclouds(my_scene['token'], \n",
     "#                                             'CAM_BACK', \n",
-    "#                                             filter_lidarseg_labels=[6, 36],\n",
+    "#                                             filter_lidarseg_labels=[15, 30],\n",
     "#                                             render_if_no_points=True, \n",
     "#                                             verbose=True, \n",
     "#                                             imsize=(1280, 720))"
@@ -304,7 +306,7 @@
    "outputs": [],
    "source": [
     "# nusc.render_camera_channel_with_pointclouds(my_scene['token'], 'CAM_BACK',\n",
-    "#                                             filter_lidarseg_labels=[6, 36],\n",
+    "#                                             filter_lidarseg_labels=[15, 30],\n",
     "#                                             render_if_no_points=True,\n",
     "#                                             verbose=True,\n",
     "#                                             imsize=(1280, 720),\n",
@@ -327,7 +329,7 @@
    "outputs": [],
    "source": [
     "# nusc.render_camera_channel_with_pointclouds(my_scene['token'], 'CAM_BACK',\n",
-    "#                                             filter_lidarseg_labels=[6],\n",
+    "#                                             filter_lidarseg_labels=[15],\n",
     "#                                             render_if_no_points=True,\n",
     "#                                             verbose=True,\n",
     "#                                             imsize=(1280, 720),\n",
@@ -351,7 +353,7 @@
    "outputs": [],
    "source": [
     "# nusc.render_scene_with_pointclouds_for_all_cameras(my_scene['token'], \n",
-    "#                                                    filter_lidarseg_labels=[32, 1],\n",
+    "#                                                    filter_lidarseg_labels=[26, 9],\n",
     "#                                                    out_path=os.path.expanduser('~/Desktop/my_rendered_scene.avi'))"
    ]
   },
@@ -388,7 +390,7 @@
     "                                camera_channel='CAM_BACK',\n",
     "                                render_intensity=False,\n",
     "                                show_lidarseg_labels=True,\n",
-    "                                filter_lidarseg_labels=[3, 4, 5],\n",
+    "                                filter_lidarseg_labels=[9, 14, 18],\n",
     "                                show_lidarseg_legend=True,\n",
     "                                verbose=True,\n",
     "                                lidarseg_preds_bin_path=my_predictions_bin_file)"
@@ -418,7 +420,7 @@
     "\n",
     "# nusc.render_camera_channel_with_pointclouds(my_scene['token'], \n",
     "#                                             'CAM_BACK', \n",
-    "#                                             filter_lidarseg_labels=[6, 36],\n",
+    "#                                             filter_lidarseg_labels=[15, 30],\n",
     "#                                             render_if_no_points=True, \n",
     "#                                             verbose=True, \n",
     "#                                             imsize=(1280, 720),\n",
@@ -450,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -49,8 +49,6 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "import sys, os\n",
-    "sys.path.insert(0, os.path.expanduser('~/Desktop/nuscenes-devkit/python-sdk'))\n",
     "from nuscenes import NuScenes\n",
     "\n",
     "nusc = NuScenes(version='v1.0-mini', dataroot='/data/sets/nuscenes', verbose=True)"


### PR DESCRIPTION
### This PR will:
- Flip ['CAM_BACK_LEFT', 'CAM_BACK', 'CAM_BACK_RIGHT']  for aesthetic reasons
- Fix extra padding and axes appearing when rendering in notebook
- Enable `render_scene_with_pointclouds_for_all_cameras` to output frames as images
- Update indices used in the examples in tutorial