### PR TITLE
Add render_centerlines method

### DIFF
--- a/python-sdk/nuscenes/map_expansion/arcline_path_utils.py
+++ b/python-sdk/nuscenes/map_expansion/arcline_path_utils.py
@@ -117,7 +117,7 @@ def pose_at_length(arcline_path: ArcLinePath,
 
     path_length = sum(arcline_path['segment_length'])
 
-    assert -1e-6 <= pos <= path_length
+    assert 1e-6 <= pos
 
     pos = max(0.0, min(pos, path_length))
 

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -682,7 +682,8 @@ class NuScenesMapExplorer:
         # Render connectivity lines.
         plt.figure(figsize=self._get_figsize(figsize))
         for pose_list in pose_lists:
-            plt.plot(pose_list[:, 0], pose_list[:, 1])
+            if len(pose_list) > 0:
+                plt.plot(pose_list[:, 0], pose_list[:, 1])
 
     def render_map_mask(self,
                         patch_box: Tuple[float, float, float, float],

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -220,7 +220,7 @@ class NuScenesMap:
                       layer_name: str,
                       token: str,
                       alpha: float = 0.5,
-                      figsize: Tuple[int, int] = (15, 15),
+                      figsize: Tuple[float, float] = None,
                       other_layers: List[str] = None) -> Tuple[Figure, Tuple[Axes, Axes]]:
         """
          Render a single map record. By default will also render 3 layers which are `drivable_area`, `lane`,
@@ -237,7 +237,7 @@ class NuScenesMap:
     def render_layers(self,
                       layer_names: List[str],
                       alpha: float = 0.5,
-                      figsize: Tuple[int, int] = (15, 15),
+                      figsize: Union[None, float, Tuple[float, float]] = None,
                       tokens: List[str] = None) -> Tuple[Figure, Axes]:
         """
         Render a list of layer names.
@@ -327,6 +327,15 @@ class NuScenesMap:
                                                           render_egoposes=render_egoposes,
                                                           render_egoposes_range=render_egoposes_range,
                                                           render_legend=render_legend)
+
+    def render_connectivity(self, resolution_meters: float = 0.5, figsize: Tuple[int, int] = None) -> None:
+        """
+        Render the connectivity of all lanes and lane connectors.
+        :param resolution_meters: How finely to discretize the lane. Smaller values ensure curved
+            lanes are properly represented.
+        :param figsize: Size of the figure.
+        """
+        self.explorer.render_connectivity(resolution_meters=resolution_meters, figsize=figsize)
 
     def render_map_mask(self,
                         patch_box: Tuple[float, float, float, float],
@@ -557,7 +566,7 @@ class NuScenesMap:
                           x: float,
                           y: float,
                           alpha: float = 0.5,
-                          figsize: Tuple[int, int] = (15, 15)) -> None:
+                          figsize: Union[None, float, Tuple[float, float]] = None) -> None:
         """
         Renders the possible next roads from a point of interest.
         :param x: x coordinate of the point of interest.
@@ -654,6 +663,26 @@ class NuScenesMapExplorer:
         self.canvas_max_y = self.map_api.canvas_edge[1]
         self.canvas_min_y = 0
         self.canvas_aspect_ratio = (self.canvas_max_x - self.canvas_min_x) / (self.canvas_max_y - self.canvas_min_y)
+
+    def render_connectivity(self, resolution_meters: float, figsize: Tuple[int, int]) -> None:
+        """
+        Render the connectivity of all lanes and lane connectors.
+        :param resolution_meters: How finely to discretize the lane. Smaller values ensure curved
+            lanes are properly represented.
+        :param figsize: Size of the figure.
+        """
+        # Discretize all lanes ann lane connectors.
+        nusc_map = self.map_api
+        pose_lists = []
+        for lane in nusc_map.lane + nusc_map.lane_connector:
+            my_lane = nusc_map.arcline_path_3.get(lane['token'], [])
+            discretized = np.array(discretize_lane(my_lane, resolution_meters))
+            pose_lists.append(discretized)
+
+        # Render connectivity lines.
+        plt.figure(figsize=self._get_figsize(figsize))
+        for pose_list in pose_lists:
+            plt.plot(pose_list[:, 0], pose_list[:, 1])
 
     def render_map_mask(self,
                         patch_box: Tuple[float, float, float, float],
@@ -801,7 +830,7 @@ class NuScenesMapExplorer:
                       layer_name: str,
                       token: str,
                       alpha: float = 0.5,
-                      figsize: Tuple[int, int] = (15, 15),
+                      figsize: Union[None, float, Tuple[float, float]] = None,
                       other_layers: List[str] = None) -> Tuple[Figure, Tuple[Axes, Axes]]:
         """
         Render a single map record.
@@ -829,7 +858,7 @@ class NuScenesMapExplorer:
         local_aspect_ratio = local_width / local_height
 
         # We obtained the values 0.65 and 0.66 by trials.
-        fig = plt.figure(figsize=figsize)
+        fig = plt.figure(figsize=self._get_figsize(figsize))
         global_ax = fig.add_axes([0, 0, 0.65, 0.65 / self.canvas_aspect_ratio])
         local_ax = fig.add_axes([0.66, 0.66 / self.canvas_aspect_ratio, 0.34, 0.34 / local_aspect_ratio])
 
@@ -875,7 +904,7 @@ class NuScenesMapExplorer:
     def render_layers(self,
                       layer_names: List[str],
                       alpha: float,
-                      figsize: Tuple[int, int],
+                      figsize: Union[None, float, Tuple[float, float]],
                       tokens: List[str] = None) -> Tuple[Figure, Axes]:
         """
         Render a list of layers.
@@ -885,7 +914,7 @@ class NuScenesMapExplorer:
         :param tokens: Optional list of tokens to render. None means all tokens are rendered.
         :return: The matplotlib figure and axes of the rendered layers.
         """
-        fig = plt.figure(figsize=figsize)
+        fig = plt.figure(figsize=self._get_figsize(figsize))
         ax = fig.add_axes([0, 0, 1, 1 / self.canvas_aspect_ratio])
 
         ax.set_xlim(self.canvas_min_x, self.canvas_max_x)
@@ -904,7 +933,7 @@ class NuScenesMapExplorer:
                          box_coords: Tuple[float, float, float, float],
                          layer_names: List[str] = None,
                          alpha: float = 0.5,
-                         figsize: Tuple[int, int] = (15, 15),
+                         figsize: Tuple[float, float] = (15, 15),
                          render_egoposes_range: bool = True,
                          render_legend: bool = True) -> Tuple[Figure, Axes]:
         """
@@ -1212,7 +1241,7 @@ class NuScenesMapExplorer:
                           x: float,
                           y: float,
                           alpha: float = 0.5,
-                          figsize: Tuple[int, int] = (15, 15)) -> None:
+                          figsize: Union[None, float, Tuple[float, float]] = None) -> None:
         """
         Renders the possible next roads from a point of interest.
         :param x: x coordinate of the point of interest.
@@ -1944,3 +1973,25 @@ class NuScenesMapExplorer:
         patch = affinity.rotate(patch, patch_angle, origin=(patch_x, patch_y), use_radians=False)
 
         return patch
+
+    def _get_figsize(self, figsize: Union[None, float, Tuple[float, float]]) -> Tuple[float, float]:
+        """
+        Utility function that scales the figure size by the map canvas size.
+        If figsize is:
+        - None      => Return default scale.
+        - Scalar    => Scale canvas size.
+        - Two-tuple => Use the specified figure size.
+        :param figsize: The input figure size.
+        :return: The output figure size.
+        """
+        # Divide canvas size by arbitrary scalar to get into cm range.
+        canvas_size = np.array(self.map_api.canvas_edge)[::-1] / 200
+
+        if figsize is None:
+            return tuple(canvas_size)
+        elif type(figsize) in [int, float]:
+            return tuple(canvas_size * figsize)
+        elif type(figsize) == tuple and len(figsize) == 2:
+            return figsize
+        else:
+            raise Exception('Error: Invalid figsize: %s' % figsize)

--- a/python-sdk/tutorials/map_expansion_tutorial.ipynb
+++ b/python-sdk/tutorials/map_expansion_tutorial.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Setup\n",
+    "## Setup\n",
     "To install the map expansion, please download the files from https://www.nuscenes.org/download and copy the files into your nuScenes map folder, e.g. `/data/sets/nuscenes/maps`."
    ]
   },
@@ -42,7 +42,11 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "import tqdm\n",
+    "import numpy as np\n",
+    "\n",
     "from nuscenes.map_expansion.map_api import NuScenesMap\n",
+    "from nuscenes.map_expansion import arcline_path_utils\n",
     "\n",
     "nusc_map = NuScenesMap(dataroot='/data/sets/nuscenes', map_name='singapore-onenorth')"
    ]
@@ -78,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = nusc_map.render_layers(nusc_map.non_geometric_layers, figsize=(15, 15))"
+    "fig, ax = nusc_map.render_layers(nusc_map.non_geometric_layers, figsize=1)"
    ]
   },
   {
@@ -118,7 +122,7 @@
    "source": [
     "patch_box = (300, 1700, 100, 100)\n",
     "patch_angle = 0  # Default orientation where North is up\n",
-    "layer_names = ['drivable_area', 'ped_crossing']\n",
+    "layer_names = ['drivable_area', 'walkway']\n",
     "canvas_size = (1000, 1000)\n",
     "map_mask = nusc_map.get_map_mask(patch_box, patch_angle, layer_names, canvas_size)\n",
     "map_mask[0]"
@@ -137,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "figsize = (22, 10)\n",
+    "figsize = (12, 4)\n",
     "fig, ax = nusc_map.render_map_mask(patch_box, patch_angle, layer_names, canvas_size, figsize=figsize, n_row=1)"
    ]
   },
@@ -239,14 +243,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nusc_map.render_next_roads(x, y)"
+    "nusc_map.render_next_roads(x, y, figsize=1)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Working with Lanes"
+    "### Working with Lanes\n",
+    "For the prediction challenge we added connectivity information to the map expansion (v1.2) to efficiently query which lane is connected to which other lanes. Let's render the lane and lane_connectivity objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nusc_map.render_connectivity(resolution_meters=0.5, figsize=1)"
    ]
   },
   {
@@ -309,7 +323,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nuscenes.map_expansion import arcline_path_utils\n",
     "poses = arcline_path_utils.discretize_lane(lane_record, resolution_meters=1)\n",
     "poses"
    ]
@@ -1097,7 +1110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/python-sdk/tutorials/map_expansion_tutorial.ipynb
+++ b/python-sdk/tutorials/map_expansion_tutorial.ipynb
@@ -251,7 +251,7 @@
    "metadata": {},
    "source": [
     "### Working with Lanes\n",
-    "For the prediction challenge we added connectivity information to the map expansion (v1.2) to efficiently query which lane is connected to which other lanes. Let's render the lane and lane_connectivity objects:"
+    "For the prediction challenge we added connectivity information to the map expansion (v1.2) to efficiently query which lane is connected to which other lanes. Below we render the lane and lane_connectivity objects. The lanes and lane_connectors are defined by parametric curves. The `resolution_meters` parameter specifies the discretization resolution of the curve. If we set it to a high value (e.g. 100), the curves will appear as straight lines."
    ]
   },
   {

--- a/python-sdk/tutorials/map_expansion_tutorial.ipynb
+++ b/python-sdk/tutorials/map_expansion_tutorial.ipynb
@@ -251,7 +251,7 @@
    "metadata": {},
    "source": [
     "### Working with Lanes\n",
-    "For the prediction challenge we added connectivity information to the map expansion (v1.2) to efficiently query which lane is connected to which other lanes. Below we render the lane and lane_connectivity objects. The lanes and lane_connectors are defined by parametric curves. The `resolution_meters` parameter specifies the discretization resolution of the curve. If we set it to a high value (e.g. 100), the curves will appear as straight lines."
+    "For the prediction challenge we added connectivity information to the map expansion (v1.2) to efficiently query which lane is connected to which other lanes. Below we render the lane and lane_connector objects. The lanes and lane_connectors are defined by parametric curves. The `resolution_meters` parameter specifies the discretization resolution of the curve. If we set it to a high value (e.g. 100), the curves will appear as straight lines. We recommend setting this value to 1m or less."
    ]
   },
   {
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nusc_map.render_connectivity(resolution_meters=0.5, figsize=1)"
+    "nusc_map.render_centerlines(resolution_meters=0.5, figsize=1)"
    ]
   },
   {


### PR DESCRIPTION
This PR does the following:
- Automatically determine figure size: Figure size is either None (default setting, relative to canvas size), scalar (scales canvas size) or a tuple (manually specifies the size).
- Added render_connectivity method to show how to visualize the lanes and lane_connectors. See an example below:
![connectivity](https://user-images.githubusercontent.com/39502217/85004945-bba55800-b18a-11ea-802f-6504abdee354.png)
- Fix bug with high discretization resolution for arcline paths. Previously the maximum possible `resolution_meters` that did not return an error was the minimum of the lengths of all paths in the map. Now it is simply clipped for each path if it exceeds the length.
