### PR TITLE
Remove render_if_no_points argument from lidarseg tutorial

### DIFF
--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -193,37 +193,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Say you happen to choose a camera channel where there are no points to show after filtering; you can set ```render_if_no_points=False``` so that nothing is displayed / saved in this case. For example, if we filter to see bicycles and objects which are pushable or pullable, and there are no points belonging to those classes, then:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nusc.render_pointcloud_in_image(my_sample['token'],\n",
-    "                                pointsensor_channel='LIDAR_TOP',\n",
-    "                                camera_channel='CAM_BACK',\n",
-    "                                render_intensity=False,\n",
-    "                                show_lidarseg=True,\n",
-    "                                filter_lidarseg_labels=[21, 11],\n",
-    "                                show_lidarseg_legend=True,\n",
-    "                                verbose=True,\n",
-    "                                render_if_no_points=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This might be useful when you want to render a bunch of sample tokens, but only for those which contain useful information (i.e. points belonging to certain classes) in them."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Render sample (i.e. lidar, radar and all cameras)\n",
     "Of course, like in the original nuScenes devkit, you can render all the sensors at once with ```render_sample```. In this extended nuScenes devkit, you can set ```show_lidarseg=True``` to see the lidarseg labels. Similar to the above methods, you can use ```filter_lidarseg_labels``` to display only the classes you wish to see."
    ]
@@ -315,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When `render_mode='image', only frames which contain points (after the filter has been applied) will be saved as images."
+    "When `render_mode='image'`, only frames which contain points (after the filter has been applied) will be saved as images."
    ]
   },
   {
@@ -336,6 +305,7 @@
    "source": [
     "# nusc.render_scene_lidarseg(my_scene['token'], \n",
     "#                            filter_lidarseg_labels=[26, 9],\n",
+    "#                            dpi=100,\n",
     "#                            out_path=os.path.expanduser('~/Desktop/my_rendered_scene.avi'))"
    ]
   },

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -214,7 +214,7 @@
    "metadata": {},
    "source": [
     "## Render a scene for a given camera sensor with lidarseg labels\n",
-    "You can also render an entire scene with the lidarseg labels for a camera of your choosing (the ```filter_lidarseg_labels``` and ```render_if_no_points``` arguments are present here as well)."
+    "You can also render an entire scene with the lidarseg labels for a camera of your choosing (the ```filter_lidarseg_labels``` argument can be used here as well)."
    ]
   },
   {


### PR DESCRIPTION
### This PR will:
- Remove the `render_if_no_points` argument from the relevant examples, and text
- Remove the section which discusses the functionality of the `render_if_no_points` argument