### PR TITLE
Function documentation typo

### DIFF
--- a/python-sdk/nuscenes/prediction/input_representation/utils.py
+++ b/python-sdk/nuscenes/prediction/input_representation/utils.py
@@ -17,7 +17,7 @@ def convert_to_pixel_coords(location: Tuple[float, float],
     :param location: Location in global coordinates as (x, y) tuple.
     :param center_of_image_in_global: Center of the image in global coordinates (x, y) tuple.
     :param center_of_image_in_pixels: Center of the image in pixel coordinates (row_pixel, column pixel).
-    :param resolution: Center of image.
+    :param resolution: Resolution of image in pixels / meters.
     """
 
     x, y = location


### PR DESCRIPTION
Update the documentation of the function "convert_to_pixel_coords" 
from 
     :param resolution: Center of image.
to 
    :param resolution: Resolution of image in pixels / meters.