### PR TITLE
Updated render_depth method (v2)

### DIFF
--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -532,8 +532,8 @@ class NuImages:
         mask = np.logical_and(mask, points[0, :] < im_size[0] - 1)
         mask = np.logical_and(mask, points[1, :] > 1)
         mask = np.logical_and(mask, points[1, :] < im_size[1] - 1)
-        points = points[:, mask]
-        depths = depths[mask]
+        points = points[:2, mask]
+        depths = depths[mask].squeeze()
 
         return points, depths, closest_time_diff, im_size
 
@@ -761,19 +761,55 @@ class NuImages:
             plt.savefig(out_path, bbox_inches='tight', dpi=2.295 * pix_to_inch, pad_inches=0)
             plt.close()
 
-    def render_depth(self,
-                     sd_token_camera: str,
-                     mode: str = 'sparse',
-                     max_depth: float = None,
-                     cmap: str = 'viridis',
-                     render_scale: float = 1.0,
-                     out_path: str = None) -> None:
+    def render_depth_sparse(self,
+                            sd_token_camera: str,
+                            render_scale: float = 1.0,
+                            point_size: float = 10.0,
+                            out_path: str = None) -> None:
         """
-        This function plots an image and its depth map, either as a set of sparse points, or with depth completion.
+        This function plots an image and the projected lidar points.
+        The points are colored by depth.
+        :param sd_token_camera: The sample_data token of the camera image.
+        :param render_scale: The scale at which the depth image will be rendered. Use 1.0 for the recommended size.
+        :param point_size: The size of each lidar point in pixels.
+        :param out_path: Optional path to save the rendered figure to disk, or otherwise None.
+            If a path is provided, the plot is not shown to the user.
+        """
+        # Get depth and image.
+        points, depths, _, im_size = self.get_depth(sd_token_camera)
+
+        # Init plot.
+        (width, height) = im_size
+        pix_to_inch = 100 / render_scale
+        figsize = (height / pix_to_inch, width / pix_to_inch)
+        plt.figure(figsize=figsize)
+        plt.axis('off')
+
+        # Show image.
+        sd_camera = self.get('sample_data', sd_token_camera)
+        im_path = osp.join(self.dataroot, sd_camera['filename'])
+        im = Image.open(im_path)
+        plt.imshow(im)
+
+        # Overlay points
+        plt.scatter(points[0], points[1], marker='.', s=point_size, c=depths)
+
+        # Save to disk.
+        if out_path is not None:
+            plt.savefig(out_path, bbox_inches='tight', dpi=2.295 * pix_to_inch, pad_inches=0)
+            plt.close()
+
+    def render_depth_dense(self,
+                           sd_token_camera: str,
+                           max_depth: float = None,
+                           cmap: str = 'viridis',
+                           render_scale: float = 1.0,
+                           out_path: str = None) -> None:
+        """
+        This function plots a dense depth map using depth completion.
         Depth completion dilates the sparse set of points in the image to "interpolate" between them.
         Default depth colors range from yellow (close) to blue (far). Missing values are blue.
         :param sd_token_camera: The sample_data token of the camera image.
-        :param mode: How to render the depth, either sparse or dense.
         :param max_depth: The maximum depth used for scaling the color values. If None, the actual maximum is used.
         :param cmap: The matplotlib color map name. We recommend viridis or magma.
         :param render_scale: The scale at which the depth image will be rendered. Use 1.0 for the recommended size.
@@ -786,17 +822,11 @@ class NuImages:
         points, depths, _, im_size = self.get_depth(sd_token_camera)
 
         # Compute depth image.
-        assert mode in ['sparse', 'dense'], 'Error: Unknown mode %s!' % mode
-        if mode == 'sparse':
-            scale = 1 / 8 * render_scale
-            n_dilate = None
-            n_gauss = None
-            sigma_gauss = None
-        else:
-            scale = 1 / 2 * render_scale
-            n_dilate = 23
-            n_gauss = 11
-            sigma_gauss = 3
+        # Show dense point image after depth completion.
+        scale = 1 / 2 * render_scale
+        n_dilate = 23
+        n_gauss = 11
+        sigma_gauss = 3
         depth_im = depth_map(points, depths, im_size, scale=scale, n_dilate=n_dilate, n_gauss=n_gauss,
                              sigma_gauss=sigma_gauss)
 

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -775,7 +775,7 @@ class NuImages:
         :param out_path: Optional path to save the rendered figure to disk, or otherwise None.
             If a path is provided, the plot is not shown to the user.
         """
-        # Get depth and image.
+        # Get depth.
         points, depths, _, im_size = self.get_depth(sd_token_camera)
 
         # Init plot.
@@ -791,7 +791,7 @@ class NuImages:
         im = Image.open(im_path)
         plt.imshow(im)
 
-        # Overlay points
+        # Overlay points.
         plt.scatter(points[0], points[1], marker='.', s=point_size, c=depths)
 
         # Save to disk.
@@ -802,6 +802,10 @@ class NuImages:
     def render_depth_dense(self,
                            sd_token_camera: str,
                            max_depth: float = None,
+                           depth_map_scale: float = 0.5,
+                           n_dilate: int = 23,
+                           n_gauss: int = 11,
+                           sigma_gauss: float = 3,
                            cmap: str = 'viridis',
                            render_scale: float = 1.0,
                            out_path: str = None) -> None:
@@ -812,22 +816,21 @@ class NuImages:
         :param sd_token_camera: The sample_data token of the camera image.
         :param max_depth: The maximum depth used for scaling the color values. If None, the actual maximum is used.
         :param cmap: The matplotlib color map name. We recommend viridis or magma.
+        :param depth_map_scale: Down-sampling factor when computing the depth map.
+        :param n_dilate: Dilation filter size.
+        :param n_gauss: Gaussian filter size.
+        :param sigma_gauss: Gaussian filter sigma.
         :param render_scale: The scale at which the depth image will be rendered. Use 1.0 for the recommended size.
             A larger scale makes the point location more precise, but they will be harder to see.
             For the "dense" option, the depth completion parameters are optimized for the recommended size.
         :param out_path: Optional path to save the rendered figure to disk, or otherwise None.
             If a path is provided, the plot is not shown to the user.
         """
-        # Get depth and image.
+        # Get depth.
         points, depths, _, im_size = self.get_depth(sd_token_camera)
 
-        # Compute depth image.
-        # Show dense point image after depth completion.
-        scale = 1 / 2 * render_scale
-        n_dilate = 23
-        n_gauss = 11
-        sigma_gauss = 3
-        depth_im = depth_map(points, depths, im_size, scale=scale, n_dilate=n_dilate, n_gauss=n_gauss,
+        # Compute dense depth image.
+        depth_im = depth_map(points, depths, im_size, scale=depth_map_scale, n_dilate=n_dilate, n_gauss=n_gauss,
                              sigma_gauss=sigma_gauss)
 
         # Scale depth_im to full image size.

--- a/python-sdk/nuimages/scripts/render_images.py
+++ b/python-sdk/nuimages/scripts/render_images.py
@@ -188,9 +188,9 @@ def write_image(nuim: NuImages, sd_token_camera: str, mode: str, out_path: str) 
     elif mode == 'image':
         nuim.render_image(sd_token_camera, with_annotations=False, out_path=out_path)
     elif mode == 'depth_dense':
-        nuim.render_depth(sd_token_camera, mode='dense', out_path=out_path)
+        nuim.render_depth_dense(sd_token_camera, out_path=out_path)
     elif mode == 'depth_sparse':
-        nuim.render_depth(sd_token_camera, mode='sparse', out_path=out_path)
+        nuim.render_depth_sparse(sd_token_camera, out_path=out_path)
     elif mode == 'pointcloud':
         nuim.render_pointcloud(sd_token_camera, out_path=out_path)
     elif mode == 'trajectory':

--- a/python-sdk/nuimages/tests/test_overflow_bug.py
+++ b/python-sdk/nuimages/tests/test_overflow_bug.py
@@ -8,4 +8,4 @@ tokens = [
 
 nuim = NuImages(version='v1.0-val', verbose=False)
 for token in tokens:
-    nuim.render_depth(token)
+    nuim.render_depth_dense(token)

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -290,7 +290,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As mentioned, most images have an associated lidar pointcloud. We can project this pointcloud to the image and display it using `render_depth()`. "
+    "As mentioned, most images have an associated lidar pointcloud. We can project this pointcloud to the image and display it using `render_depth_sparse()`. "
    ]
   },
   {
@@ -299,14 +299,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.render_depth(sd_token_camera, mode='sparse')"
+    "nuim.render_depth_sparse(sd_token_camera)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the pointcloud is relatively sparse, this image is hard to see. We can enable depth completion of the pointcloud to get a denser version of the image using `mode='dense'`. To get the raw data of this plot, use `get_depth()`."
+    "Since the pointcloud is relatively sparse, this image is hard to see. We can enable depth completion of the pointcloud to get a denser version of the image using `render_depth_dense()`. To get the raw data of this plot, use `get_depth()`."
    ]
   },
   {
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.render_depth(sd_token_camera, mode='dense')"
+    "nuim.render_depth_dense(sd_token_camera)"
    ]
   },
   {


### PR DESCRIPTION
Updated render_depth method in sparse mode to overlay the points on the images.

This replaces https://github.com/nutonomy/nuscenes-devkit/pull/436, which was based on the wrong branch.
It also separates the sparse and dense depth rendering methods to have more flexibility.