### PR TITLE
Update nuImages documentation, add ability to get segmentation masks, improve listing and rendering functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ For an advanced installation, see [installation](https://github.com/nutonomy/nus
 ## nuImages
 
 ### nuImages setup
-Note that until the release of nuImages v1.0, the files will not be available for public download.
+To download nuImages you need to go to the [Download page](https://www.nuscenes.org/download), 
+create an account and agree to the nuScenes [Terms of Use](https://www.nuscenes.org/terms-of-use).
 For the devkit to work you will need to download *all* archives.
 Please unpack the archives to the `/data/sets/nuimages` folder \*without\* overwriting folders that occur in multiple archives.
 Eventually you should have the following folder structure:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,10 +105,6 @@ pip install -r setup/requirements.txt
 ```
 **Note:** The requirements file is internally divided into base requirements (`base`) and requirements specific to certain products or challenges (`nuimages`, `prediction` and `tracking`). If you only plan to use a subset of the codebase, feel free to comment out the lines that you do not need.
 
-## Verify install
-To verify your environment run `python -m unittest` in the `python-sdk` folder.
-You can also run `assert_download.py` in the `nuscenes/scripts` folder.
-
 ## Setup environment variable
 Finally, if you want to run the unit tests you need to point the devkit to the `nuscenes` folder on your disk.
 Set the NUSCENES environment variable to point to your data folder, e.g. `/data/sets/nuscenes`:
@@ -119,4 +115,9 @@ or for nuImages:
 ```
 export NUIMAGES="/data/sets/nuimages"
 ```
+
+## Verify install
+To verify your environment run `python -m unittest` in the `python-sdk` folder.
+You can also run `assert_download.py` in the `nuscenes/scripts` folder.
+
 That's it you should be good to go!

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -5,6 +5,7 @@
 - [Objects](#objects)
   - [Bounding Boxes](#bounding-boxes)
   - [Instance Segmentation](#instance-segmentation)
+  - [Attributes](#attributes)
 - [Surfaces](#surfaces)
   - [Semantic Segmentation](#semantic-segmentation)
 
@@ -18,18 +19,7 @@ We have also [added more attributes](#attributes) in nuImages. For segmentation,
 
 # Objects
 nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels),
-while the [attributes](#attributes) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
-
-## Attributes
-The following attributes are in **addition** to the existing ones in nuScenes:
-
-|  Attribute | Short Description |
-| --- | --- |
-| vehicle_light.emergency.flashing | The emergency lights on the vehicle are flashing. |
-| vehicle_light.emergency.not_flashing | The emergency lights on the vehicle are not flashing. |
-| vertical_position.off_ground | The object is not in the ground (e.g. it is flying, falling, jumping or positioned in a tree or on a vehicle). |
-| vertical_position.on_ground | The object is on the ground plane. |
-
+while the [attributes](#attributes) are a superset of the [attributes in nuScenes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
 
 ## Bounding Boxes
 ### General Instructions
@@ -42,24 +32,15 @@ The following attributes are in **addition** to the existing ones in nuScenes:
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
  - Only label objects if the object is clear enough to be certain of what it is. If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
- - Do not label an object if its less than 20% visible. 
- The clarity and orientation of the object does not influence its visibility. 
+ - Do not label an object if its less than 20% visible, unless you can confidently tell what the object is.
  An object can have low visibility when it is occluded or cut off by the image.
- However, even when the object is less than 20% visible, it should be labeled if you can confidently tell what the object is.
+ The clarity and orientation of the object does not influence its visibility. 
  
 ### Detailed Instructions 
  - `human.pedestrian.*`
-   - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
  - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
- - `movable_object.*`
-   - For `movable_object.trafficcone`:
-     - Traffic cones do not necessarily have to be cone-shaped (e.g. there may be traffic cones which are orange-striped barrels).
-     - Permanently mounted traffic delineator posts are not traffic cones.
-     - Do not label traffic cones appended to vehicles.
-   - For `movable_object.barrier`:
-     - If there are multiple barriers either connected or just placed next to each other, they should be annotated separately.
 
 [Top](#overview)
    
@@ -83,6 +64,19 @@ The following attributes are in **addition** to the existing ones in nuScenes:
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
+
+[Top](#overview)
+
+## Attributes
+In nuImages, each object comes with a box, a mask and a set of attributes. 
+The following attributes are in **addition** to the [existing ones in nuScenes]((https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes)):
+
+|  Attribute | Short Description |
+| --- | --- |
+| vehicle_light.emergency.flashing | The emergency lights on the vehicle are flashing. |
+| vehicle_light.emergency.not_flashing | The emergency lights on the vehicle are not flashing. |
+| vertical_position.off_ground | The object is not in the ground (e.g. it is flying, falling, jumping or positioned in a tree or on a vehicle). |
+| vertical_position.on_ground | The object is on the ground plane. |
 
 [Top](#overview)
 

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -12,12 +12,13 @@
 
 # Introduction
 In nuImages, we annotate objects with 2d boxes, instance masks and 2d segmentation masks. All the labels and attributes from nuScenes are carried over into nuImages.
+We have also added more attributes in nuImages. For segmentation, we have included ["stuff" (background) classes](#surfaces).
 
 
 
 # Objects
-nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels) 
-and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes) from nuScenes.
+nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels),
+while the [attributes](TODO link to website) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
 
 
 ## Bounding Boxes
@@ -54,15 +55,11 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
  - `vehicle.*`
    - In nighttime images, annotate the vehicles only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
    - If the pivoting joint of a bus cannot be seen, annotate it as `vehicle.bus.rigid`.
+   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles, bicycles, and personal mobility vehicles), 
+   the rider (and, if applicable, the passengers as well as objects) should be included in the box for the vehicle.
+   - If there is a pedestrian standing next to the vehicle, do not include the pedestrian in the annotation.
    - For `vehicle.motorcycle`:
-     - If there is a rider, include the rider in the box.
-     - If there is a passenger, include the passenger in the box.
-     - If there is a pedestrian standing next to the motorcycle, do not include the pedestrian in the annotation.
      - If there is a sidecar attached to the motorcycle, include the sidecar in the box.
-   - For `vehicle.bicycle`:
-     - If there is a rider, include the rider in the box.
-     - If there is a passenger, include the passenger in the box.
-     - If there is a pedestrian standing next to the bicycle, do not include in the annotation.
    - For `vehicle.bicycle`:
      - Bicycles which are not part of a bicycle rack should be annotated as bicycles separately, rather than collectively as `static_object.bicycle_rack`.
    - For `vehicle.trailer`:
@@ -97,6 +94,7 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
  - If parts of an object is not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible area of the object.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
+ 
 ### Detailed Instructions 
  - `human.pedestrian.*` 
   - If a pedestrian is carrying an object (i.e. bags, umbrellas, tools), include it in the polygon. 
@@ -106,6 +104,8 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
    (Exceptions are the crane arms on construction vehicles).
    - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
    - If a vehicle is carrying people or bicycles, these are considered part of the object and should be included in the polygon.
+   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles, bicycles, and personal mobility vehicles), 
+   the rider (and, if applicable, the passengers as well as objects) should be included in the polygon for the vehicle.
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
 

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -28,8 +28,7 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
  - If an object is occluded, then draw the bounding box to include the occluded part of the object according to your best guess.
  - If an object is cut off at the edge of the image, then the bounding box should stop at the image boundary.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
- - If an object has extremities, the bounding box should include **all** the extremities. 
- (Exceptions are the side view mirrors and antennas of vehicles).
+ - If an object has extremities, the bounding box should include **all** the extremities (exceptions are the side view mirrors and antennas of vehicles).
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
  - Only label objects if the object is clear enough to be certain of what it is. 
  If an object is so blurry it cannot be known, do not label the object.
@@ -100,10 +99,7 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
   - If a pedestrian is carrying an object (i.e. bags, umbrellas, tools), include it in the polygon. 
   If the pedestrian is dragging an object, then do not include it.
  - `vehicle.*`
-   - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.)
-   (Exceptions are the crane arms on construction vehicles).
-   - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
-   - If a vehicle is carrying people or bicycles, these are considered part of the object and should be included in the polygon.
+   - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
    - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles, bicycles, and personal mobility vehicles), 
    the rider (and, if applicable, the passengers as well as objects) should be included in the polygon for the vehicle.
  - `static_object.bicycle_rack`

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -27,15 +27,17 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - Do not apply more than one box to a single object.
  - If an object is occluded, then draw the bounding box to include the occluded part of the object according to your best guess.
  
- [![](occluded_vehicle_8.png)]() [![](occluded_vehicle_9.png)]() 
+![bboxes_occlusion_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_occlusion_1.png) 
+![bboxes_occlusion_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_occlusion_2.png)
  - If an object is cut off at the edge of the image, then the bounding box should stop at the image boundary.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
- [![](mirror_image_1.png)]() 
+![bboxes_reflection](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_reflection.png) 
  - If an object has extremities, the bounding box should include **all** the extremities (exceptions are the side view mirrors and antennas of vehicles).
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
  
- [![](extremity_5.png)]() [![](extremity_4.png)]()
+![bboxes_extremity_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_extremity_1.png)
+![bboxes_extremity_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_extremity_2.png)
  - Only label objects if the object is clear enough to be certain of what it is. If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
  - Do not label an object if its less than 20% visible, unless you can confidently tell what the object is.
@@ -46,13 +48,14 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - `human.pedestrian.*`
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
    
-   [![](nighttime_pedestrian_fp_1.png)]() [![](nighttime_pedestrian_fp_2.png)]() 
+![bboxes_pedestrian_nighttime_fp_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_pedestrian_nighttime_fp_1.png) 
+![bboxes_pedestrian_nighttime_fp_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_pedestrian_nighttime_fp_2.png)
  - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
    
-   [![](nighttime_vehicle_fp_1.png)]() 
-   [![](nighttime_vehicle_fp_2.png)]() 
-   [![](nighttime_vehicle_fn_1.png)]()
+![bboxes_vehicle_nighttime_fp_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_vehicle_nighttime_fp_1.png)
+![bboxes_vehicle_nighttime_fp_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_vehicle_nighttime_fp_2.png)
+![bboxes_vehicle_nighttime_fn_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/bboxes_vehicle_nighttime_fn_1.png)
    
 [Top](#overview)
    
@@ -63,36 +66,34 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - There should not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), then the external object can be included in the polygon.
  
- [![](inst11.png)]()
- [![](inst12.png)]()
+![instanceseg_occlusion5pix_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_occlusion5pix_1.png)
  - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
  
- [![](inst_seg_v2_19.png)]()
+![instanceseg_covered](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_covered.png)
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  do not create a polygon on that visible area.
  
- [![](inst16.png)]()
+![instanceseg_hole_another_object](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_hole_another_object.png)
  - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area.
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
  
- [![](inst17.png)]()
+![instanceseg_hole_another_object_exempt](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_hole_another_object_exempt.png)
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
  
- [![](inst_seg_v2_21.png)]()
- [![](inst_seg_v2_22.png)]()
+![instanceseg_attached_object_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_attached_object_1.png)
  - If parts of an object are not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible areas of the object.
  
- [![](inst24.png)]()
+![instanceseg_guess](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_guess.png)
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
- [![](inst25.png)]()
+![instanceseg_reflection](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_reflection.png)
  
 ### Detailed Instructions 
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
    
-   [![](inst8.png)]()
-   [![](inst10.png)]()
+![instanceseg_extremity](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_extremity.png)
+![instanceseg_extremity_exempt](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_extremity_exempt.png)
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
 
@@ -137,25 +138,25 @@ nuImages includes surface classes as well:
  - Only annotate a surface if its length and width are **both** greater than 20 pixels.
  - Annotations should tightly bound the edges of the area(s) of interest. 
  
- [![](no_gaps.png)]()
+![surface_no_gaps](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_no_gaps.png)
  - If two areas/objects of interest are adjacent to each other, there should be no gap between the two annotations.
  
- [![](polygon_tight.png)]()
+![surface_adjacent](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_adjacent.png)
  - Annotate a surface only as far as it is clearly visible.
- 
- [![](rules1.png)]()
+
+![surface_far_visible](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_far_visible.png)
  - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas (which are more than 20 pixels in length and width).
  
- [![]()]()
+![surface_occlusion_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_occlusion_2.png)
  - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation (since it can be safely driven over).
  
- [![]()]()
+![surface_snow](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_snow.png)
  - If a surface has puddles in it, always include them in the annotation.
  - Do not annotate reflections of surfaces.
 
 ### Detailed Instructions 
  - `flat.driveable_surface`
    - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
-   [![](dirveable_surface14.png)]()
+![surface_occlusion_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_occlusion_1.png)
 
 [Top](#overview)

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -18,7 +18,7 @@ We have also [added more attributes](#attributes) in nuImages. For segmentation,
 
 
 # Objects
-nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels),
+nuImages contains the [same object classes as nuScenes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels),
 while the [attributes](#attributes) are a superset of the [attributes in nuScenes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
 
 ## Bounding Boxes
@@ -95,7 +95,7 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
 ![instanceseg_extremity](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_extremity.png)
 ![instanceseg_extremity_exempt](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/instanceseg_extremity_exempt.png)
  - `static_object.bicycle_rack`
-   - All bicycles in a bicycle rack should not be annotated.
+   - All bicycles in a bicycle rack should be annotated collectively as bicycle rack.
 
 [Top](#overview)
 

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -18,7 +18,26 @@ We have also added more attributes in nuImages. For segmentation, we have includ
 
 # Objects
 nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels),
-while the [attributes](TODO link to website) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
+while the [attributes](#attributes) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
+
+## Attributes
+The objects have attribute annotations such as whether a motorcycle has a rider, the pose of a pedestrian, the activity of a vehicle, 
+flashing emergency lights and whether an animal is flying. These are the attributes in nuImages:
+
+|  Attribute | Short Description |
+| --- | --- |
+| cycle.with_rider | There is a rider on the motorcycle. |
+| cycle.without_rider | There is no rider on the motorcycle. |
+| pedestrian.moving | The pedestrian is moving (e.g. running, walking). |
+| pedestrian.sitting_lying | The pedestrian is sitting (crouching and kneeling are also considered sitting) or lying down (i.e. the body of the pedestrian is horizontal to the ground plane). |
+| pedestrian.standing | The pedestrian is standing or bending down. |
+| vehicle.moving | The vehicle is moving. |
+| vehicle.parked | The vehicle is stationary (usually for a long duration) with no immediate intent to move. |
+| vehicle.stopped | The vehicle, with a driver/rider in / on it, is currently stationary but has an intent to move. |
+| vehicle_light.emergency.flashing | The emergency lights on the vehicle are flashing. |
+| vehicle_light.emergency.not_flashing | The emergency lights on the vehicle are not flashing. |
+| vertical_position.off_ground | The object is not in the ground (e.g. it is flying, falling, jumping or positioned in a tree or on a vehicle). |
+| vertical_position.on_ground | The object is on the ground plane. |
 
 
 ## Bounding Boxes
@@ -41,33 +60,11 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
 ### Detailed Instructions 
  - `human.pedestrian.*`
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
-   - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible 
-   (leg, arm, head etc.), or the person is clearly in motion.
-   - If a pedestrian is carrying an object (e.g. children, bags, umbrellas, tools), the object should be included 
-   in the bounding box for the pedestrian.
+   - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
    - If two or more pedestrians are carrying the same object, the bounding box of only one of them will include the object.
    - If a pedestrian is pulling or pushing an object, the pedestrian and the object should be annotated separately.
-   - If a person is in a stroller / wheelchair, include the person in the annotation for `human.pedestrian.stroller` / `human.pedestrian.wheelchair`.
-   - Pedestrians pushing strollers / wheelchairs should be labeled separately.
-   - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
-   - If there is uncertainty about the type of the pedestrian (`human.pedestrian.adult` vs `human.pedestrian.child` vs `human.pedestrian.construction_worker`, etc.), choose `human.pedestrian.adult`.
- - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
-   - If the pivoting joint of a bus cannot be seen, annotate it as `vehicle.bus.rigid`.
-   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles and bicycles), 
-   the rider (and, if applicable, the passengers as well as objects) should be included in the box for the vehicle.
-   - If there is a pedestrian standing next to the vehicle, do not include the pedestrian in the annotation.
-   - For `vehicle.motorcycle`:
-     - If there is a sidecar attached to the motorcycle, include the sidecar in the box.
-   - For `vehicle.bicycle`:
-     - Bicycles which are not part of a bicycle rack should be annotated as bicycles separately, rather than collectively as `static_object.bicycle_rack`.
-   - For `vehicle.trailer`:
-     - A vehicle towed by another vehicle should be labeled with its corresponding vehicle type (not as `vehicle.trailer`).
  - `movable_object.*`
-   - Movable objects do not include pedestrians, bicycles, wheelchairs, and strollers.
-   - Do not label movable signs or small barriers which are not on the road.
-   - Do not label permanent pedestrian walk signs, even when they are on the road.
-   - Do not label permanently mounted poles.
    - For `movable_object.trafficcone`:
      - Traffic cones do not necessarily have to be cone-shaped (e.g. there may be traffic cones which are orange-striped barrels).
      - Permanently mounted traffic delineator posts are not traffic cones.
@@ -82,9 +79,8 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
 ### General Instructions
  - Given a bounding box, outline the **visible** parts of the object enclosed within the bounding box using a polygon.
  - Each pixel on the image should be assigned to at most one object instance (i.e. the polygons should not overlap).
- - There should be not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
- - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), 
- then the external object can be included in the polygon.
+ - There should not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
+ - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), then the external object can be included in the polygon.
  - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  not create a polygon on that visible area.
@@ -95,13 +91,8 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
 ### Detailed Instructions 
- - `human.pedestrian.*` 
-  - If a pedestrian is carrying an object (i.e. bags, umbrellas, tools), include it in the polygon. 
-  If the pedestrian is dragging an object, then do not include it.
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
-   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles and bicycles), 
-   the rider (and, if applicable, the passengers as well as objects) should be included in the polygon for the vehicle.
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
 
@@ -127,22 +118,13 @@ nuImages includes surface classes as well:
  - Annotations should tightly bound the edges of the area(s) of interest. 
  - If two areas/objects of interest are adjacent to each other, there should be no gap between the two annotations.
  - Annotate a surface only as far as it is clearly visible.
- - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas 
- (which are more than 20 pixels in length and width).
- - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation 
- (since it can be safely driven over).
+ - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas (which are more than 20 pixels in length and width).
+ - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation (since it can be safely driven over).
  - If a surface has puddles in it, always include them in the annotation.
  - Do not annotate reflections of surfaces.
 
 ### Detailed Instructions 
  - `flat.driveable_surface`
-   - All lanes and directions of traffic should be included. 
-   Road, driveways (including the space where the driveway intersects the sidewalk), pedestrian crosswalks, 
-   parking lots and road shoulders should also be included. Obstacles on the road (e.g vehicles, pedestrians) should be excluded from the outline.
-   - Include walkable surface between traffic islands but exclude the elevated traffic islands.
-   - Do not include sidewalks.
    - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
- - `vehicle.ego`
-   - The entire ego vehicle should be annotated, including any sensors that can be seen in the frame.
 
 [Top](#overview)

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -71,7 +71,7 @@ The following attributes are in **addition** to the existing ones in nuScenes:
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), then the external object can be included in the polygon.
  - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
- not create a polygon on that visible area.
+ do not create a polygon on that visible area.
  - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area. 
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -27,15 +27,15 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - Do not apply more than one box to a single object.
  - If an object is occluded, then draw the bounding box to include the occluded part of the object according to your best guess.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/occluded_vehicle_8.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/occluded_vehicle_9.png)]() 
+ [![](occluded_vehicle_8.png)]() [![](occluded_vehicle_9.png)]() 
  - If an object is cut off at the edge of the image, then the bounding box should stop at the image boundary.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/mirror_image_1.png)]() 
+ [![](mirror_image_1.png)]() 
  - If an object has extremities, the bounding box should include **all** the extremities (exceptions are the side view mirrors and antennas of vehicles).
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/extremity_5.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/extremity_4.png)]()
+ [![](extremity_5.png)]() [![](extremity_4.png)]()
  - Only label objects if the object is clear enough to be certain of what it is. If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
  - Do not label an object if its less than 20% visible, unless you can confidently tell what the object is.
@@ -46,13 +46,13 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - `human.pedestrian.*`
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
    
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_pedestrian_fp_1.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_pedestrian_fp_2.png)]() 
+   [![](nighttime_pedestrian_fp_1.png)]() [![](nighttime_pedestrian_fp_2.png)]() 
  - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
    
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fp_1.png)]() 
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fp_2.png)]() 
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fn_1.png)]()
+   [![](nighttime_vehicle_fp_1.png)]() 
+   [![](nighttime_vehicle_fp_2.png)]() 
+   [![](nighttime_vehicle_fn_1.png)]()
    
 [Top](#overview)
    
@@ -63,36 +63,36 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - There should not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), then the external object can be included in the polygon.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst11.png)]()
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst12.png)]()
+ [![](inst11.png)]()
+ [![](inst12.png)]()
  - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_19.png)]()
+ [![](inst_seg_v2_19.png)]()
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  do not create a polygon on that visible area.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst16.png)]()
+ [![](inst16.png)]()
  - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area.
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst17.png)]()
+ [![](inst17.png)]()
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_21.png)]()
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_22.png)]()
+ [![](inst_seg_v2_21.png)]()
+ [![](inst_seg_v2_22.png)]()
  - If parts of an object are not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible areas of the object.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst24.png)]()
+ [![](inst24.png)]()
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst25.png)]()
+ [![](inst25.png)]()
  
 ### Detailed Instructions 
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
    
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst8.png)]()
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst10.png)]()
+   [![](inst8.png)]()
+   [![](inst10.png)]()
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
 
@@ -137,25 +137,25 @@ nuImages includes surface classes as well:
  - Only annotate a surface if its length and width are **both** greater than 20 pixels.
  - Annotations should tightly bound the edges of the area(s) of interest. 
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/new_endpoint/no_gaps.png)]()
+ [![](no_gaps.png)]()
  - If two areas/objects of interest are adjacent to each other, there should be no gap between the two annotations.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/new_endpoint/polygon_tight.png)]()
+ [![](polygon_tight.png)]()
  - Annotate a surface only as far as it is clearly visible.
  
- [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/ground/rules1.png)]()
+ [![](rules1.png)]()
  - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas (which are more than 20 pixels in length and width).
  
- [![](https://camo.githubusercontent.com/dfbfa4c8a61590f81761ba1e7b47d68fe5d92773/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6e75746f6e6f6d792d696d64622d64756d6d792f73656d616e7469635f7365675f6578616d706c65732f6e65775f656e64706f696e742f6275736865732e706e67)]()
+ [![]()]()
  - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation (since it can be safely driven over).
  
- [![](https://camo.githubusercontent.com/c48c2fcbf2b8d59cf123680cffda0f03223b38f8/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6e75746f6e6f6d792d696d64622d64756d6d792f73656d616e7469635f7365675f6578616d706c65732f67726f756e642f72756c657331322e706e67)]()
+ [![]()]()
  - If a surface has puddles in it, always include them in the annotation.
  - Do not annotate reflections of surfaces.
 
 ### Detailed Instructions 
  - `flat.driveable_surface`
    - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
-   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/driveable_surface14.png)]()
+   [![](dirveable_surface14.png)]()
 
 [Top](#overview)

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -21,19 +21,10 @@ nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes
 while the [attributes](#attributes) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
 
 ## Attributes
-The objects have attribute annotations such as whether a motorcycle has a rider, the pose of a pedestrian, the activity of a vehicle, 
-flashing emergency lights and whether an animal is flying. These are the attributes in nuImages:
+The following attributes are in addition to the existing ones in nuScenes:
 
 |  Attribute | Short Description |
 | --- | --- |
-| cycle.with_rider | There is a rider on the motorcycle. |
-| cycle.without_rider | There is no rider on the motorcycle. |
-| pedestrian.moving | The pedestrian is moving (e.g. running, walking). |
-| pedestrian.sitting_lying | The pedestrian is sitting (crouching and kneeling are also considered sitting) or lying down (i.e. the body of the pedestrian is horizontal to the ground plane). |
-| pedestrian.standing | The pedestrian is standing or bending down. |
-| vehicle.moving | The vehicle is moving. |
-| vehicle.parked | The vehicle is stationary (usually for a long duration) with no immediate intent to move. |
-| vehicle.stopped | The vehicle, with a driver/rider in / on it, is currently stationary but has an intent to move. |
 | vehicle_light.emergency.flashing | The emergency lights on the vehicle are flashing. |
 | vehicle_light.emergency.not_flashing | The emergency lights on the vehicle are not flashing. |
 | vertical_position.off_ground | The object is not in the ground (e.g. it is flying, falling, jumping or positioned in a tree or on a vehicle). |

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -40,8 +40,7 @@ The following attributes are in addition to the existing ones in nuScenes:
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  - If an object has extremities, the bounding box should include **all** the extremities (exceptions are the side view mirrors and antennas of vehicles).
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
- - Only label objects if the object is clear enough to be certain of what it is. 
- If an object is so blurry it cannot be known, do not label the object.
+ - Only label objects if the object is clear enough to be certain of what it is. If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
  - Do not label an object if its less than 20% visible. 
  The clarity and orientation of the object does not influence its visibility. 
@@ -52,8 +51,6 @@ The following attributes are in addition to the existing ones in nuScenes:
  - `human.pedestrian.*`
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
-   - If two or more pedestrians are carrying the same object, the bounding box of only one of them will include the object.
-   - If a pedestrian is pulling or pushing an object, the pedestrian and the object should be annotated separately.
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
  - `movable_object.*`
    - For `movable_object.trafficcone`:

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -21,7 +21,7 @@ nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes
 while the [attributes](#attributes) are a superset of the [attributes in nuScenes.](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes).
 
 ## Attributes
-The following attributes are in addition to the existing ones in nuScenes:
+The following attributes are in **addition** to the existing ones in nuScenes:
 
 |  Attribute | Short Description |
 | --- | --- |
@@ -51,6 +51,7 @@ The following attributes are in addition to the existing ones in nuScenes:
  - `human.pedestrian.*`
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
+  = `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
  - `movable_object.*`
    - For `movable_object.trafficcone`:
@@ -59,7 +60,6 @@ The following attributes are in addition to the existing ones in nuScenes:
      - Do not label traffic cones appended to vehicles.
    - For `movable_object.barrier`:
      - If there are multiple barriers either connected or just placed next to each other, they should be annotated separately.
-     - If the barriers are installed permanently, then do not include them.
 
 [Top](#overview)
    

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -51,7 +51,7 @@ The following attributes are in **addition** to the existing ones in nuScenes:
  - `human.pedestrian.*`
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
-  = `vehicle.*`
+ - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
  - `movable_object.*`
    - For `movable_object.trafficcone`:

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -22,12 +22,14 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
 
 ## Bounding Boxes
 ### General Instructions
- - Draw bounding boxes around all objects that are in the list of [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels)
+ - Draw bounding boxes around all objects that are in the list of [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels).
  - Do not apply more than one box to a single object.
- - If an object is occluded or cut off by the edge of the image, then draw the bounding box to include the occluded part of the object according to your best guess.
+ - If an object is occluded, then draw the bounding box to include the occluded part of the object according to your best guess.
+ - If an object is cut off at the edge of the image, then the bounding box should stop at the image boundary.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  - If an object has extremities, the bounding box should include **all** the extremities. 
  (Exceptions are the side view mirrors and antennas of vehicles).
+ Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
  - Only label objects if the object is clear enough to be certain of what it is. 
  If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
@@ -41,24 +43,17 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
    - In nighttime images, annotate the pedestrian only when either body part(s) of a person is clearly visible 
    (leg, arm, head etc.), or the person is clearly in motion.
-   - If a pedestrian is carrying an object (e.g. children, bags, umbrellas tools), the object should be included 
+   - If a pedestrian is carrying an object (e.g. children, bags, umbrellas, tools), the object should be included 
    in the bounding box for the pedestrian.
    - If two or more pedestrians are carrying the same object, the bounding box of only one of them will include the object.
    - If a pedestrian is pulling or pushing an object, the pedestrian and the object should be annotated separately.
    - If a person is in a stroller / wheelchair, include the person in the annotation for `human.pedestrian.stroller` / `human.pedestrian.wheelchair`.
    - Pedestrians pushing strollers / wheelchairs should be labeled separately.
-   - If a person in on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
-   - If there is uncertainty about the type of the pedestrian (`human.pedestrian.adult` vs `human.pedestrian.child` vs `human.pedestrian.construction_worker`, etc.),
-    choose `human.pedestrian.adult`.
+   - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
+   - If there is uncertainty about the type of the pedestrian (`human.pedestrian.adult` vs `human.pedestrian.child` vs `human.pedestrian.construction_worker`, etc.), choose `human.pedestrian.adult`.
  - `vehicle.*`
-   - In nighttime images annotate, the vehicles only when a pair of lights is clearly visible (break or head or hazard lights), 
-   and it is clearly on the road surface.
-   - Do not include side view mirrors and antennas of vehicles.
-   - If a vehicle is primarily designed to haul cargo, label it as `vehicle.truck`.
-   - If a vehicle is primarily designed to carry more than 10 people, label it as `vehicle.bus.*`.
+   - In nighttime images, annotate the vehicles only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
    - If the pivoting joint of a bus cannot be seen, annotate it as `vehicle.bus.rigid`.
-   - Trailers hauled after a semi-tractor should be labeled as `vehicle.trailer`.
-   - Vehicles used for hauling rocks or building materials are considered `vehicle.truck` rather than `vehicle.construction`.
    - For `vehicle.motorcycle`:
      - If there is a rider, include the rider in the box.
      - If there is a passenger, include the passenger in the box.
@@ -67,10 +62,9 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
    - For `vehicle.bicycle`:
      - If there is a rider, include the rider in the box.
      - If there is a passenger, include the passenger in the box.
-     - If there is a pedestrian standing next to the bicycle, do NOT include in the annotation.
+     - If there is a pedestrian standing next to the bicycle, do not include in the annotation.
    - For `vehicle.bicycle`:
-     - Bicycles which are not part of a bicycle rack should be annotated as bicycles separately, 
-     rather than collectively as `static_object.bicycle_rack`.
+     - Bicycles which are not part of a bicycle rack should be annotated as bicycles separately, rather than collectively as `static_object.bicycle_rack`.
    - For `vehicle.trailer`:
      - A vehicle towed by another vehicle should be labeled with its corresponding vehicle type (not as `vehicle.trailer`).
  - `movable_object.*`
@@ -80,7 +74,7 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
    - Do not label permanently mounted poles.
    - For `movable_object.trafficcone`:
      - Traffic cones do not necessarily have to be cone-shaped (e.g. there may be traffic cones which are orange-striped barrels).
-     - Permanently mounted traffic delineator posts are NOT traffic cones.
+     - Permanently mounted traffic delineator posts are not traffic cones.
      - Do not label traffic cones appended to vehicles.
    - For `movable_object.barrier`:
      - If there are multiple barriers either connected or just placed next to each other, they should be annotated separately.
@@ -92,11 +86,11 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
 ### General Instructions
  - Given a bounding box, outline the **visible** parts of the object enclosed within the bounding box using a polygon.
  - Each pixel on the image should be assigned to at most one object instance (i.e. the polygons should not overlap).
- - There should be not be a discrepancy of more than 2 pixels discrepancy between the edge of the object instance and the polygon.
+ - There should be not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), 
  then the external object can be included in the polygon.
  - If an object is loosely covered by another object (e.g. branches bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
- - If an object is enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
+ - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  not create a polygon on that visible area.
  - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area. 
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
@@ -110,10 +104,10 @@ and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/in
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.)
    (Exceptions are the crane arms on construction vehicles).
-   - If a person in on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
+   - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
    - If a vehicle is carrying people or bicycles, these are considered part of the object and should be included in the polygon.
  - `static_object.bicycle_rack`
-   - All bicycles in a bicycle rack should be annotated.
+   - All bicycles in a bicycle rack should not be annotated.
 
 [Top](#overview)
 
@@ -127,8 +121,9 @@ nuImages includes surface classes as well:
 | [`vehicle.ego`](#2-vehicleego) | The vehicle on which the cameras, radar and lidar are mounted, that is sometimes visible at the bottom of the image. |
 
 ### 1. flat.driveable_surface
+[### TODO add examples images of class]
 ### 2. vehicle.ego
-
+[### TODO add examples images of class]
 
 ## Semantic Segmentation
 ### General Instructions
@@ -142,15 +137,15 @@ nuImages includes surface classes as well:
  (since it can be safely driven over).
  - If a surface has puddles in it, always include them in the annotation.
  - Do not annotate reflections of surfaces.
- 
+
 ### Detailed Instructions 
  - `flat.driveable_surface`
    - All lanes and directions of traffic should be included. 
    Road, driveways (including the space where the driveway intersects the sidewalk), pedestrian crosswalks, 
    parking lots and road shoulders should also be included. Obstacles on the road (e.g vehicles, pedestrians) should be excluded from the outline.
-   - Include walkable surface between traffic islands but excludes the elevated traffic islands.
+   - Include walkable surface between traffic islands but exclude the elevated traffic islands.
    - Do not include sidewalks.
-   - Include surface blocked by road blockers or pillars as long as they are the same surface from the driveable surface.
+   - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
  - `vehicle.ego`
    - The entire ego vehicle should be annotated, including any sensors that can be seen in the frame.
 

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -157,6 +157,7 @@ nuImages includes surface classes as well:
 ### Detailed Instructions 
  - `flat.driveable_surface`
    - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
+
 ![surface_occlusion_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/correct-wrong/surface_occlusion_1.png)
 
 [Top](#overview)

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -12,7 +12,7 @@
 
 # Introduction
 In nuImages, we annotate objects with 2d boxes, instance masks and 2d segmentation masks. All the labels and attributes from nuScenes are carried over into nuImages.
-We have also added more attributes in nuImages. For segmentation, we have included ["stuff" (background) classes](#surfaces).
+We have also [added more attributes](#attributes) in nuImages. For segmentation, we have included ["stuff" (background) classes](#surfaces).
 
 
 

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -121,9 +121,16 @@ nuImages includes surface classes as well:
 | [`vehicle.ego`](#2-vehicleego) | The vehicle on which the cameras, radar and lidar are mounted, that is sometimes visible at the bottom of the image. |
 
 ### 1. flat.driveable_surface
-[### TODO add examples images of class]
+![driveable_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/driveable_1.png)
+![driveable_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/driveable_2.png)
+![driveable_3](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/driveable_3.png)
+![driveable_4](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/driveable_4.png)
+
 ### 2. vehicle.ego
-[### TODO add examples images of class]
+![ego_1](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/ego_1.png)
+![ego_2](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/ego_2.png)
+![ego_3](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/ego_3.png)
+![ego_4](https://www.nuscenes.org/public/images/taxonomy_imgs/nuimages/ego_4.png)
 
 ## Semantic Segmentation
 ### General Instructions

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -41,7 +41,7 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
 ### Detailed Instructions 
  - `human.pedestrian.*`
    - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
-   - In nighttime images, annotate the pedestrian only when either body part(s) of a person is clearly visible 
+   - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible 
    (leg, arm, head etc.), or the person is clearly in motion.
    - If a pedestrian is carrying an object (e.g. children, bags, umbrellas, tools), the object should be included 
    in the bounding box for the pedestrian.
@@ -52,9 +52,9 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
    - If a person is on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
    - If there is uncertainty about the type of the pedestrian (`human.pedestrian.adult` vs `human.pedestrian.child` vs `human.pedestrian.construction_worker`, etc.), choose `human.pedestrian.adult`.
  - `vehicle.*`
-   - In nighttime images, annotate the vehicles only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
+   - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
    - If the pivoting joint of a bus cannot be seen, annotate it as `vehicle.bus.rigid`.
-   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles, bicycles, and personal mobility vehicles), 
+   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles and bicycles), 
    the rider (and, if applicable, the passengers as well as objects) should be included in the box for the vehicle.
    - If there is a pedestrian standing next to the vehicle, do not include the pedestrian in the annotation.
    - For `vehicle.motorcycle`:
@@ -64,8 +64,8 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
    - For `vehicle.trailer`:
      - A vehicle towed by another vehicle should be labeled with its corresponding vehicle type (not as `vehicle.trailer`).
  - `movable_object.*`
-   - Movable objects do not include pedestrians, bicycles, wheel-chairs, and strollers.
-   - Do not label movable signs or small barriers not on the road.
+   - Movable objects do not include pedestrians, bicycles, wheelchairs, and strollers.
+   - Do not label movable signs or small barriers which are not on the road.
    - Do not label permanent pedestrian walk signs, even when they are on the road.
    - Do not label permanently mounted poles.
    - For `movable_object.trafficcone`:
@@ -85,13 +85,13 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
  - There should be not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), 
  then the external object can be included in the polygon.
- - If an object is loosely covered by another object (e.g. branches bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
+ - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  not create a polygon on that visible area.
  - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area. 
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
- - If parts of an object is not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible area of the object.
+ - If parts of an object are not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible areas of the object.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
  
 ### Detailed Instructions 
@@ -100,7 +100,7 @@ while the [attributes](TODO link to website) are a superset of the [attributes i
   If the pedestrian is dragging an object, then do not include it.
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
-   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles, bicycles, and personal mobility vehicles), 
+   - If there is a rider (and any passengers or objects) in the vehicle (or on the vehicle, in the case of motorcycles and bicycles), 
    the rider (and, if applicable, the passengers as well as objects) should be included in the polygon for the vehicle.
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -26,10 +26,16 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - Draw bounding boxes around all objects that are in the list of [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels).
  - Do not apply more than one box to a single object.
  - If an object is occluded, then draw the bounding box to include the occluded part of the object according to your best guess.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/occluded_vehicle_8.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/occluded_vehicle_9.png)]() 
  - If an object is cut off at the edge of the image, then the bounding box should stop at the image boundary.
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/mirror_image_1.png)]() 
  - If an object has extremities, the bounding box should include **all** the extremities (exceptions are the side view mirrors and antennas of vehicles).
  Note that this differs [from how the instance masks are annotated](#instance-segmentation), in which the extremities are included in the masks.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/extremity_5.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_200/extremity_4.png)]()
  - Only label objects if the object is clear enough to be certain of what it is. If an object is so blurry it cannot be known, do not label the object.
  - Do not label an object if its height is less than 10 pixels.
  - Do not label an object if its less than 20% visible, unless you can confidently tell what the object is.
@@ -39,9 +45,15 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
 ### Detailed Instructions 
  - `human.pedestrian.*`
    - In nighttime images, annotate the pedestrian only when either the body part(s) of a person is clearly visible (leg, arm, head etc.), or the person is clearly in motion.
+   
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_pedestrian_fp_1.png)]() [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_pedestrian_fp_2.png)]() 
  - `vehicle.*`
    - In nighttime images, annotate a vehicle only when a pair of lights is clearly visible (break or head or hazard lights), and it is clearly on the road surface.
-
+   
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fp_1.png)]() 
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fp_2.png)]() 
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/example_imgs/resized_400/nighttime_vehicle_fn_1.png)]()
+   
 [Top](#overview)
    
 ## Instance Segmentation
@@ -50,18 +62,37 @@ while the [attributes](#attributes) are a superset of the [attributes in nuScene
  - Each pixel on the image should be assigned to at most one object instance (i.e. the polygons should not overlap).
  - There should not be a discrepancy of more than 2 pixels between the edge of the object instance and the polygon.
  - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), then the external object can be included in the polygon.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst11.png)]()
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst12.png)]()
  - If an object is loosely covered by another object (e.g. branches, bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_19.png)]()
  - If an object enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
  do not create a polygon on that visible area.
- - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area. 
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst16.png)]()
+ - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area.
  Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst17.png)]()
  - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_21.png)]()
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst_seg_v2_22.png)]()
  - If parts of an object are not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible areas of the object.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst24.png)]()
  - If an object is reflected clearly in a glass window, then the reflection should be annotated.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst25.png)]()
  
 ### Detailed Instructions 
  - `vehicle.*`
    - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.); exceptions are the crane arms on construction vehicles.
+   
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst8.png)]()
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/instance_seg_examples/inst10.png)]()
  - `static_object.bicycle_rack`
    - All bicycles in a bicycle rack should not be annotated.
 
@@ -98,15 +129,26 @@ nuImages includes surface classes as well:
 ### General Instructions
  - Only annotate a surface if its length and width are **both** greater than 20 pixels.
  - Annotations should tightly bound the edges of the area(s) of interest. 
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/new_endpoint/no_gaps.png)]()
  - If two areas/objects of interest are adjacent to each other, there should be no gap between the two annotations.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/new_endpoint/polygon_tight.png)]()
  - Annotate a surface only as far as it is clearly visible.
+ 
+ [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/ground/rules1.png)]()
  - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas (which are more than 20 pixels in length and width).
+ 
+ [![](https://camo.githubusercontent.com/dfbfa4c8a61590f81761ba1e7b47d68fe5d92773/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6e75746f6e6f6d792d696d64622d64756d6d792f73656d616e7469635f7365675f6578616d706c65732f6e65775f656e64706f696e742f6275736865732e706e67)]()
  - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation (since it can be safely driven over).
+ 
+ [![](https://camo.githubusercontent.com/c48c2fcbf2b8d59cf123680cffda0f03223b38f8/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6e75746f6e6f6d792d696d64622d64756d6d792f73656d616e7469635f7365675f6578616d706c65732f67726f756e642f72756c657331322e706e67)]()
  - If a surface has puddles in it, always include them in the annotation.
  - Do not annotate reflections of surfaces.
 
 ### Detailed Instructions 
  - `flat.driveable_surface`
    - Include surfaces blocked by road blockers or pillars as long as they are the same surface as the driveable surface.
+   [![](https://s3.amazonaws.com/nutonomy-imdb-dummy/semantic_seg_examples/driveable_surface14.png)]()
 
 [Top](#overview)

--- a/docs/instructions_nuimages.md
+++ b/docs/instructions_nuimages.md
@@ -1,1 +1,157 @@
-TODO: Coming soon!
+# nuImages Annotator Instructions
+
+# Overview
+- [Introduction](#introduction)
+- [Objects](#objects)
+  - [Bounding Boxes](#bounding-boxes)
+  - [Instance Segmentation](#instance-segmentation)
+- [Surfaces](#surfaces)
+  - [Semantic Segmentation](#semantic-segmentation)
+
+
+
+# Introduction
+In nuImages, we annotate objects with 2d boxes, instance masks and 2d segmentation masks. All the labels and attributes from nuScenes are carried over into nuImages.
+
+
+
+# Objects
+nuImages contains the same [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels) 
+and [attributes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#attributes) from nuScenes.
+
+
+## Bounding Boxes
+### General Instructions
+ - Draw bounding boxes around all objects that are in the list of [object classes](https://github.com/nutonomy/nuscenes-devkit/tree/master/docs/instructions_nuscenes.md#labels)
+ - Do not apply more than one box to a single object.
+ - If an object is occluded or cut off by the edge of the image, then draw the bounding box to include the occluded part of the object according to your best guess.
+ - If an object is reflected clearly in a glass window, then the reflection should be annotated.
+ - If an object has extremities, the bounding box should include **all** the extremities. 
+ (Exceptions are the side view mirrors and antennas of vehicles).
+ - Only label objects if the object is clear enough to be certain of what it is. 
+ If an object is so blurry it cannot be known, do not label the object.
+ - Do not label an object if its height is less than 10 pixels.
+ - Do not label an object if its less than 20% visible. 
+ The clarity and orientation of the object does not influence its visibility. 
+ An object can have low visibility when it is occluded or cut off by the image.
+ However, even when the object is less than 20% visible, it should be labeled if you can confidently tell what the object is.
+ 
+### Detailed Instructions 
+ - `human.pedestrian.*`
+   - People inside / on vehicles should not be annotated as pedestrians. They are considered as appendages of vehicles.
+   - In nighttime images, annotate the pedestrian only when either body part(s) of a person is clearly visible 
+   (leg, arm, head etc.), or the person is clearly in motion.
+   - If a pedestrian is carrying an object (e.g. children, bags, umbrellas tools), the object should be included 
+   in the bounding box for the pedestrian.
+   - If two or more pedestrians are carrying the same object, the bounding box of only one of them will include the object.
+   - If a pedestrian is pulling or pushing an object, the pedestrian and the object should be annotated separately.
+   - If a person is in a stroller / wheelchair, include the person in the annotation for `human.pedestrian.stroller` / `human.pedestrian.wheelchair`.
+   - Pedestrians pushing strollers / wheelchairs should be labeled separately.
+   - If a person in on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
+   - If there is uncertainty about the type of the pedestrian (`human.pedestrian.adult` vs `human.pedestrian.child` vs `human.pedestrian.construction_worker`, etc.),
+    choose `human.pedestrian.adult`.
+ - `vehicle.*`
+   - In nighttime images annotate, the vehicles only when a pair of lights is clearly visible (break or head or hazard lights), 
+   and it is clearly on the road surface.
+   - Do not include side view mirrors and antennas of vehicles.
+   - If a vehicle is primarily designed to haul cargo, label it as `vehicle.truck`.
+   - If a vehicle is primarily designed to carry more than 10 people, label it as `vehicle.bus.*`.
+   - If the pivoting joint of a bus cannot be seen, annotate it as `vehicle.bus.rigid`.
+   - Trailers hauled after a semi-tractor should be labeled as `vehicle.trailer`.
+   - Vehicles used for hauling rocks or building materials are considered `vehicle.truck` rather than `vehicle.construction`.
+   - For `vehicle.motorcycle`:
+     - If there is a rider, include the rider in the box.
+     - If there is a passenger, include the passenger in the box.
+     - If there is a pedestrian standing next to the motorcycle, do not include the pedestrian in the annotation.
+     - If there is a sidecar attached to the motorcycle, include the sidecar in the box.
+   - For `vehicle.bicycle`:
+     - If there is a rider, include the rider in the box.
+     - If there is a passenger, include the passenger in the box.
+     - If there is a pedestrian standing next to the bicycle, do NOT include in the annotation.
+   - For `vehicle.bicycle`:
+     - Bicycles which are not part of a bicycle rack should be annotated as bicycles separately, 
+     rather than collectively as `static_object.bicycle_rack`.
+   - For `vehicle.trailer`:
+     - A vehicle towed by another vehicle should be labeled with its corresponding vehicle type (not as `vehicle.trailer`).
+ - `movable_object.*`
+   - Movable objects do not include pedestrians, bicycles, wheel-chairs, and strollers.
+   - Do not label movable signs or small barriers not on the road.
+   - Do not label permanent pedestrian walk signs, even when they are on the road.
+   - Do not label permanently mounted poles.
+   - For `movable_object.trafficcone`:
+     - Traffic cones do not necessarily have to be cone-shaped (e.g. there may be traffic cones which are orange-striped barrels).
+     - Permanently mounted traffic delineator posts are NOT traffic cones.
+     - Do not label traffic cones appended to vehicles.
+   - For `movable_object.barrier`:
+     - If there are multiple barriers either connected or just placed next to each other, they should be annotated separately.
+     - If the barriers are installed permanently, then do not include them.
+
+[Top](#overview)
+   
+## Instance Segmentation
+### General Instructions
+ - Given a bounding box, outline the **visible** parts of the object enclosed within the bounding box using a polygon.
+ - Each pixel on the image should be assigned to at most one object instance (i.e. the polygons should not overlap).
+ - There should be not be a discrepancy of more than 2 pixels discrepancy between the edge of the object instance and the polygon.
+ - If an object is occluded by another object whose width is less than 5 pixels (e.g. a thin fence), 
+ then the external object can be included in the polygon.
+ - If an object is loosely covered by another object (e.g. branches bushes), do not create several polygons for visible areas that are less than 15 pixels in diameter.
+ - If an object is enclosed by the bounding box is occluded by another foreground object but has a visible area through a glass window (like for cars / vans / trucks), 
+ not create a polygon on that visible area.
+ - If an object has a visible area through a hole of another foreground object, create a polygon on the visible area. 
+ Exemptions would be holes from bicycle / motorcycles / bike racks and holes that are less than 15 pixels diameter.
+ - If a static / moveable object has another object attached to it (signboard, rope), include it in the annotation.
+ - If parts of an object is not visible due to lighting and / or shadow, it is best to have an educated guess on the non-visible area of the object.
+ - If an object is reflected clearly in a glass window, then the reflection should be annotated.
+### Detailed Instructions 
+ - `human.pedestrian.*` 
+  - If a pedestrian is carrying an object (i.e. bags, umbrellas, tools), include it in the polygon. 
+  If the pedestrian is dragging an object, then do not include it.
+ - `vehicle.*`
+   - Include extremities (e.g. side view mirrors, taxi heads, police sirens, etc.)
+   (Exceptions are the crane arms on construction vehicles).
+   - If a person in on a personal mobility vehicle (e.g. skateboard, Segway, scooter), include the person in the annotation for `human.pedestrian.personal_mobility`.
+   - If a vehicle is carrying people or bicycles, these are considered part of the object and should be included in the polygon.
+ - `static_object.bicycle_rack`
+   - All bicycles in a bicycle rack should be annotated.
+
+[Top](#overview)
+
+
+# Surfaces
+nuImages includes surface classes as well:
+
+|  Label | Short Description |
+| --- | --- |
+| [`flat.driveable_surface`](#1-flatdriveable_surface) | All paved or unpaved surfaces that a car can drive on with no concern of traffic rules. |
+| [`vehicle.ego`](#2-vehicleego) | The vehicle on which the cameras, radar and lidar are mounted, that is sometimes visible at the bottom of the image. |
+
+### 1. flat.driveable_surface
+### 2. vehicle.ego
+
+
+## Semantic Segmentation
+### General Instructions
+ - Only annotate a surface if its length and width are **both** greater than 20 pixels.
+ - Annotations should tightly bound the edges of the area(s) of interest. 
+ - If two areas/objects of interest are adjacent to each other, there should be no gap between the two annotations.
+ - Annotate a surface only as far as it is clearly visible.
+ - If a surface is occluded (e.g. by branches, trees, fence poles), only annotate the visible areas 
+ (which are more than 20 pixels in length and width).
+ - If a surface is covered by dirt or snow of less than 20 cm in height, include the dirt or snow in the annotation 
+ (since it can be safely driven over).
+ - If a surface has puddles in it, always include them in the annotation.
+ - Do not annotate reflections of surfaces.
+ 
+### Detailed Instructions 
+ - `flat.driveable_surface`
+   - All lanes and directions of traffic should be included. 
+   Road, driveways (including the space where the driveway intersects the sidewalk), pedestrian crosswalks, 
+   parking lots and road shoulders should also be included. Obstacles on the road (e.g vehicles, pedestrians) should be excluded from the outline.
+   - Include walkable surface between traffic islands but excludes the elevated traffic islands.
+   - Do not include sidewalks.
+   - Include surface blocked by road blockers or pillars as long as they are the same surface from the driveable surface.
+ - `vehicle.ego`
+   - The entire ego vehicle should be annotated, including any sensors that can be seen in the frame.
+
+[Top](#overview)

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -694,7 +694,17 @@ class NuImages:
         nuim_name2idx_mapping = dict()
         # The 0 index is reserved for non-labelled background; thus, the categories should start from index 1.
         for i, c in enumerate(self.category, start=1):
-            nuim_name2idx_mapping[c['name']] = i
+            if c['name'] == 'vehicle.ego':  # Ensure that vehicle.ego is always mapped to index 31.
+                nuim_name2idx_mapping[c['name']] = 31
+            else:
+                nuim_name2idx_mapping[c['name']] = i
+        # Ensure that each class name is uniquely paired with a class index, and vice versa.
+        assert len(nuim_name2idx_mapping) == len(set(nuim_name2idx_mapping.values())), \
+            'Error: There are {} class names but {} class indices'.format(len(nuim_name2idx_mapping),
+                                                                          len(set(nuim_name2idx_mapping.values())))
+        assert nuim_name2idx_mapping['flat.driveable_surface'] == 24, \
+            'Error: flat.driveable_surface should be ' \
+            'index 24, not {}.'.format(nuim_name2idx_mapping['flat.driveable_surface'])
 
         # Get image data.
         self.check_sweeps(sample_data['filename'])

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -15,7 +15,7 @@ from PIL import Image, ImageDraw, ImageFont
 from pyquaternion import Quaternion
 
 from nuimages.utils.lidar import depth_map, distort_pointcloud, InvertedNormalize
-from nuimages.utils.utils import annotation_name, mask_decode
+from nuimages.utils.utils import annotation_name, mask_decode, get_font
 from nuscenes.utils.color_map import get_colormap
 from nuscenes.utils.data_classes import LidarPointCloud
 from nuscenes.utils.geometry_utils import view_points, transform_matrix
@@ -682,6 +682,7 @@ class NuImages:
                      surface_tokens: List[str] = None,
                      render_scale: float = 1.0,
                      box_line_width: int = 0,
+                     font_size: int = 20,
                      out_path: str = None) -> None:
         """
         Renders an image (sample_data), optionally with annotations overlaid.
@@ -699,6 +700,7 @@ class NuImages:
         :param render_scale: The scale at which the image will be rendered. Use 1.0 for the original image size.
         :param box_line_width: The box line width in pixels. The default is 0.
             If set to 0, box_line_width equals render_scale (rounded) to be larger in larger images.
+        :param font_size: Size of the text in the rendered image.
         :param out_path: The path where we save the rendered image, or otherwise None.
             If a path is provided, the plot is not shown to the user.
         """
@@ -720,7 +722,7 @@ class NuImages:
         im = Image.open(im_path)
 
         # Initialize drawing.
-        font = ImageFont.load_default()
+        font = get_font(fonts_valid=['FreeSerif.ttf', 'FreeSans.ttf'], font_size=font_size)
         draw = ImageDraw.Draw(im, 'RGBA')
 
         with_annotations_options = ['all', 'surfaces', 'objects', 'none']
@@ -785,6 +787,8 @@ class NuImages:
         if out_path is not None:
             plt.savefig(out_path, bbox_inches='tight', dpi=2.295 * pix_to_inch, pad_inches=0)
             plt.close()
+
+        plt.show()
 
     def render_depth_sparse(self,
                             sd_token_camera: str,

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -380,7 +380,7 @@ class NuImages:
             print('\nPrinting surface annotations:')
             for surface_ann in surface_anns:
                 category = self.get('category', surface_ann['category_token'])
-                print(surface_ann['sample_data_token'], category['name'])
+                print(surface_ann['token'], category['name'])
 
         object_tokens = [o['token'] for o in object_anns]
         surface_tokens = [s['token'] for s in surface_anns]

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -371,13 +371,13 @@ class NuImages:
         surface_anns = [o for o in self.surface_ann if o['sample_data_token'] == sd_token_camera]
 
         if verbose:
-            print('Printing foreground annotations:')
+            print('Printing object annotations:')
             for object_ann in object_anns:
                 category = self.get('category', object_ann['category_token'])
                 attribute_names = [self.get('attribute', at)['name'] for at in object_ann['attribute_tokens']]
                 print('{} {} {}'.format(object_ann['token'], category['name'], attribute_names))
 
-            print('\nPrinting background annotations:')
+            print('\nPrinting surface annotations:')
             for surface_ann in surface_anns:
                 category = self.get('category', surface_ann['category_token'])
                 print(surface_ann['sample_data_token'], category['name'])
@@ -720,12 +720,12 @@ class NuImages:
         draw = ImageDraw.Draw(im, 'RGBA')
 
         if with_annotations:
-            # Load stuff / background regions.
+            # Load stuff / surface regions.
             surface_anns = [o for o in self.surface_ann if o['sample_data_token'] == sd_token_camera]
             if surface_tokens is not None:
                 surface_anns = [o for o in surface_anns if o['token'] in surface_tokens]
 
-            # Draw stuff / background regions.
+            # Draw stuff / surface regions.
             for ann in surface_anns:
                 # Get color and mask.
                 category_token = ann['category_token']

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -288,9 +288,9 @@ class NuImages:
                 channel_freqs[sensor['channel']] += 1
 
         # Print to stdout.
-        format_str = '{:7} {:6} {:24}'
+        format_str = '{:15} {:7} {:25}'
         print()
-        print(format_str.format('Cameras', 'Samples', 'Channel'))
+        print(format_str.format('Calibr. sensors', 'Samples', 'Channel'))
         for channel in cs_freqs.keys():
             cs_freq = cs_freqs[channel]
             channel_freq = channel_freqs[channel]

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -687,7 +687,7 @@ class NuImages:
         """
         # Validate inputs.
         sample_data = self.get('sample_data', sd_token_camera)
-        assert sample_data['fileformat'] == 'jpg', 'Error: Cannot use get_seg() on lidar pointclouds!'
+        assert sample_data['fileformat'] == 'jpg', 'Error: Cannot use get_segmentation() on lidar pointclouds!'
         assert sample_data['is_key_frame'], 'Error: Cannot render annotations for non keyframes!'
 
         # Build a mapping from name to index to look up index in O(1) time.
@@ -750,7 +750,7 @@ class NuImages:
 
     def render_image(self,
                      sd_token_camera: str,
-                     annotations_type: str = 'all',
+                     annotation_type: str = 'all',
                      with_category: bool = False,
                      with_attributes: bool = False,
                      object_tokens: List[str] = None,
@@ -762,7 +762,7 @@ class NuImages:
         """
         Renders an image (sample_data), optionally with annotations overlaid.
         :param sd_token_camera: The token of the sample_data to be rendered.
-        :param annotations_type: The types of annotations to draw on the image; there are four options:
+        :param annotation_type: The types of annotations to draw on the image; there are four options:
             'all': Draw surfaces and objects, subject to any filtering done by object_tokens and surface_tokens.
             'surfaces': Draw only surfaces, subject to any filtering done by surface_tokens.
             'objects': Draw objects, subject to any filtering done by object_tokens.
@@ -783,7 +783,7 @@ class NuImages:
         sample_data = self.get('sample_data', sd_token_camera)
         assert sample_data['fileformat'] == 'jpg', 'Error: Cannot use render_image() on lidar pointclouds!'
         if not sample_data['is_key_frame']:
-            assert not annotations_type, 'Error: Cannot render annotations for non keyframes!'
+            assert not annotation_type, 'Error: Cannot render annotations for non keyframes!'
             assert not with_attributes, 'Error: Cannot render attributes for non keyframes!'
         if with_attributes:
             assert with_category, 'In order to set with_attributes=True, with_category must be True.'
@@ -797,16 +797,15 @@ class NuImages:
         im = Image.open(im_path)
 
         # Initialize drawing.
-        font = get_font(fonts_valid=['FreeSerif.ttf', 'FreeSans.ttf', 'Century.ttf', 'Calibri.ttf', 'arial.ttf'],
-                        font_size=font_size)
+        font = get_font(font_size=font_size)
         draw = ImageDraw.Draw(im, 'RGBA')
 
         annotations_types = ['all', 'surfaces', 'objects', 'none']
-        assert annotations_type in annotations_types, \
-            'Error: {} is not a valid option for with_annotations. ' \
-            'Only {} are allowed.'.format(annotations_type, annotations_types)
-        if annotations_type is not 'none':
-            if annotations_type == 'all' or annotations_type == 'surfaces':
+        assert annotation_type in annotations_types, \
+            'Error: {} is not a valid option for annotation_type. ' \
+            'Only {} are allowed.'.format(annotation_type, annotations_types)
+        if annotation_type is not 'none':
+            if annotation_type == 'all' or annotation_type == 'surfaces':
                 # Load stuff / surface regions.
                 surface_anns = [o for o in self.surface_ann if o['sample_data_token'] == sd_token_camera]
                 if surface_tokens is not None:
@@ -825,7 +824,7 @@ class NuImages:
                     # Draw mask. The label is obvious from the color.
                     draw.bitmap((0, 0), Image.fromarray(mask * 128), fill=tuple(color + (128,)))
 
-            if annotations_type == 'all' or annotations_type == 'objects':
+            if annotation_type == 'all' or annotation_type == 'objects':
                 # Load object instances.
                 object_anns = [o for o in self.object_ann if o['sample_data_token'] == sd_token_camera]
                 if object_tokens is not None:

--- a/python-sdk/nuimages/nuimages.py
+++ b/python-sdk/nuimages/nuimages.py
@@ -692,7 +692,8 @@ class NuImages:
 
         # Build a mapping from name to index to look up index in O(1) time.
         nuim_name2idx_mapping = dict()
-        for i, c in enumerate(self.category):
+        # The 0 index is reserved for non-labelled background; thus, the categories should start from index 1.
+        for i, c in enumerate(self.category, start=1):
             nuim_name2idx_mapping[c['name']] = i
 
         # Get image data.
@@ -733,13 +734,13 @@ class NuImages:
 
             # Draw masks for semantic segmentation and instance segmentation.
             semseg_mask[mask == 1] = nuim_name2idx_mapping[category_name]
-            instanceseg_mask[mask == 1] = num_instances
             num_instances += 1  # Increment the number of object instances.
+            instanceseg_mask[mask == 1] = num_instances
 
         # Ensure that the number of instances in the instance segmentation mask is the same as the number of objects.
-        assert len(object_anns) == np.max(instanceseg_mask) + 1, \
+        assert len(object_anns) == np.max(instanceseg_mask), \
             'Error: There are {} objects but only {} instances ' \
-            'were drawn into the instance segmentation mask.'.format(len(object_anns), np.max(instanceseg_mask) + 1)
+            'were drawn into the instance segmentation mask.'.format(len(object_anns), np.max(instanceseg_mask))
 
         return semseg_mask, instanceseg_mask
 

--- a/python-sdk/nuimages/utils/utils.py
+++ b/python-sdk/nuimages/utils/utils.py
@@ -4,6 +4,7 @@
 import base64
 import os
 from typing import List
+import warnings
 
 import matplotlib.font_manager
 from PIL import ImageFont
@@ -55,10 +56,14 @@ def get_font(fonts_valid: List[str], font_size: int = 15) -> ImageFont:
     """
     # Find a list of fonts within the user's system.
     fonts_in_sys = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')
+    # Sort the list of fonts to ensure that the desired fonts are always found in the same order.
+    fonts_in_sys = sorted(fonts_in_sys)
     # Of all the fonts found in the user's system, check if any of them are desired.
     for font_in_sys in fonts_in_sys:
         if any(os.path.basename(font_in_sys) in s for s in fonts_valid):
             return ImageFont.truetype(font_in_sys, font_size)
 
     # If none of the fonts in the user's system are desirable, then use the default font.
+    warnings.warn('No suitable fonts were found in your system. '
+                  'A default font will be used instead (the font size will not be adjustable).')
     return ImageFont.load_default()

--- a/python-sdk/nuimages/utils/utils.py
+++ b/python-sdk/nuimages/utils/utils.py
@@ -2,8 +2,11 @@
 # Code written by Asha Asvathaman & Holger Caesar, 2020.
 
 import base64
+import os
 from typing import List
 
+import matplotlib.font_manager
+from PIL import ImageFont
 import numpy as np
 from pycocotools import mask as cocomask
 
@@ -39,3 +42,23 @@ def mask_decode(mask: dict) -> np.ndarray:
     new_mask = mask.copy()
     new_mask['counts'] = base64.b64decode(mask['counts'])
     return cocomask.decode(new_mask)
+
+
+def get_font(fonts_valid: List[str], font_size: int = 15) -> ImageFont:
+    """
+    Check if there is a desired font present in the user's system. If there is, use that font; otherwise, use a default
+    font.
+    :param fonts_valid: A list of fonts which are desirable.
+    :param font_size: The size of the font to set. Note that if the default font is used, then the font size
+        cannot be set.
+    :return: An ImageFont object to use as the font in a PIL image.
+    """
+    # Find a list of fonts within the user's system.
+    fonts_in_sys = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')
+    # Of all the fonts found in the user's system, check if any of them are desired.
+    for font_in_sys in fonts_in_sys:
+        if any(os.path.basename(font_in_sys) in s for s in fonts_valid):
+            return ImageFont.truetype(font_in_sys, font_size)
+
+    # If none of the fonts in the user's system are desirable, then use the default font.
+    return ImageFont.load_default()

--- a/python-sdk/nuimages/utils/utils.py
+++ b/python-sdk/nuimages/utils/utils.py
@@ -45,16 +45,18 @@ def mask_decode(mask: dict) -> np.ndarray:
     return cocomask.decode(new_mask)
 
 
-def get_font(font_size: int = 15) -> ImageFont:
+def get_font(fonts_valid: List[str] = None, font_size: int = 15) -> ImageFont:
     """
     Check if there is a desired font present in the user's system. If there is, use that font; otherwise, use a default
     font.
+    :param fonts_valid: A list of fonts which are desirable.
     :param font_size: The size of the font to set. Note that if the default font is used, then the font size
         cannot be set.
     :return: An ImageFont object to use as the font in a PIL image.
     """
-    # A hardcoded list of fonts which are desirable.
-    fonts_valid = ['FreeSerif.ttf', 'FreeSans.ttf', 'Century.ttf', 'Calibri.ttf', 'arial.ttf']
+    # If there are no desired fonts supplied, use a hardcoded list of fonts which are desirable.
+    if fonts_valid is None:
+        fonts_valid = ['FreeSerif.ttf', 'FreeSans.ttf', 'Century.ttf', 'Calibri.ttf', 'arial.ttf']
 
     # Find a list of fonts within the user's system.
     fonts_in_sys = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')

--- a/python-sdk/nuimages/utils/utils.py
+++ b/python-sdk/nuimages/utils/utils.py
@@ -45,15 +45,17 @@ def mask_decode(mask: dict) -> np.ndarray:
     return cocomask.decode(new_mask)
 
 
-def get_font(fonts_valid: List[str], font_size: int = 15) -> ImageFont:
+def get_font(font_size: int = 15) -> ImageFont:
     """
     Check if there is a desired font present in the user's system. If there is, use that font; otherwise, use a default
     font.
-    :param fonts_valid: A list of fonts which are desirable.
     :param font_size: The size of the font to set. Note that if the default font is used, then the font size
         cannot be set.
     :return: An ImageFont object to use as the font in a PIL image.
     """
+    # A hardcoded list of fonts which are desirable.
+    fonts_valid = ['FreeSerif.ttf', 'FreeSans.ttf', 'Century.ttf', 'Calibri.ttf', 'arial.ttf']
+
     # Find a list of fonts within the user's system.
     fonts_in_sys = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')
     # Sort the list of fonts to ensure that the desired fonts are always found in the same order.

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -184,7 +184,7 @@
     "- vehicles: orange\n",
     "- bicycles and motorcycles: red\n",
     "- pedestrians: blue\n",
-    "- cones and barriers: black\n",
+    "- cones and barriers: gray\n",
     "- driveable surface: teal / green\n",
     "\n",
     "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object (note that we can only set `with_attributes=True` to print the attributes of each object when `with_category=True`). \n",

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -187,7 +187,7 @@
     "- cones and barriers: gray\n",
     "- driveable surface: teal / green\n",
     "\n",
-    "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object (note that we can only set `with_attributes=True` to print the attributes of each object when `with_category=True`). \n",
+    "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object (note that we can only set `with_attributes=True` to print the attributes of each object when `with_category=True`). In addition, we can specify if we want to see surfaces and objects, or only surfaces, or only objects, or neither by setting `with_annotations` to `all`, `surfaces`, `objects` and `none` respectively.\n",
     "\n",
     "Let us make the image bigger for better visibility by setting `render_scale=2`. We can also change the line width of the boxes using `box_line_width`. By setting it to 0, the line width adapts to the `render_scale`. Finally, we can rendering the image to disk using `out_path`."
    ]
@@ -198,7 +198,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.render_image(sd_token_camera, with_category=True, with_attributes=False, box_line_width=0, render_scale=2)"
+    "nuim.render_image(sd_token_camera, with_annotations='all',\n",
+    "                  with_category=True, with_attributes=False, box_line_width=0, render_scale=2)"
    ]
   },
   {

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "## Initialization\n",
-    "To initialize the dataset class, we run the code below. We can change the dataroot parameter if the dataset is installed in a different folder. We can also omit it to use the default setup."
+    "To initialize the dataset class, we run the code below. We can change the dataroot parameter if the dataset is installed in a different folder. We can also omit it to use the default setup. Note that the use of `lazy` will be explained in more detail in the **Tables** section."
    ]
   },
   {
@@ -53,15 +53,6 @@
     "from nuimages import NuImages\n",
     "\n",
     "nuim = NuImages(dataroot='/data/sets/nuimages', version='v1.0-mini', verbose=True, lazy=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lazy loading\n",
-    "\n",
-    "Initializing the NuImages instance above was very fast, as we did not actually load the tables. Rather, the class implements lazy loading that overwrites the internal `__getattr__()` function to load a table if it is not already stored in memory. This will become clearer later on in the Tables section where we access `category`; we will see the required table being loaded from disk (to disable such notifications, just set `verbose=False` when initializing the NuImages object). Furthermore lazy loading can be disabled with `lazy=False`."
    ]
   },
   {
@@ -172,6 +163,15 @@
     "\n",
     "sd_token_lidar = sample['key_lidar_token']\n",
     "print(sd_token_lidar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lazy loading\n",
+    "\n",
+    "Initializing the NuImages instance above was very fast, as we did not actually load the tables. Rather, the class implements lazy loading that overwrites the internal `__getattr__()` function to load a table if it is not already stored in memory. The moment we accessed `category`, we could see the table being loaded from disk. To disable such notifications, just set `verbose=False` when initializing the NuImages object. Furthermore lazy loading can be disabled with `lazy=False`."
    ]
   },
   {

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "## Initialization\n",
-    "To initialize the dataset class, we run the code below. We can change the dataroot parameter if the dataset is installed in a different folder. We can also omit it to use the default setup. Note that the use of `lazy` will be explained in more detail in the **Tables** section."
+    "To initialize the dataset class, we run the code below. We can change the dataroot parameter if the dataset is installed in a different folder. We can also omit it to use the default setup. These will be useful further below."
    ]
   },
   {
@@ -50,6 +50,9 @@
     "%matplotlib inline\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
+    "\n",
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.expanduser('~/Desktop/quick/nuscenes-devkit/python-sdk'))\n",
     "from nuimages import NuImages\n",
     "\n",
     "nuim = NuImages(dataroot='/data/sets/nuimages', version='v1.0-mini', verbose=True, lazy=True)"
@@ -189,7 +192,7 @@
     "\n",
     "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object (note that we can only set `with_attributes=True` to print the attributes of each object when `with_category=True`). In addition, we can specify if we want to see surfaces and objects, or only surfaces, or only objects, or neither by setting `with_annotations` to `all`, `surfaces`, `objects` and `none` respectively.\n",
     "\n",
-    "Let us make the image bigger for better visibility by setting `render_scale=2`. We can also change the line width of the boxes using `box_line_width`. By setting it to 0, the line width adapts to the `render_scale`. Finally, we can rendering the image to disk using `out_path`."
+    "Let us make the image bigger for better visibility by setting `render_scale=2`. We can also change the line width of the boxes using `box_line_width`. By setting it to -1, the line width adapts to the `render_scale`. Finally, we can render the image to disk using `out_path`."
    ]
   },
   {
@@ -198,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.render_image(sd_token_camera, with_annotations='all',\n",
+    "nuim.render_image(sd_token_camera, annotations_type='all',\n",
     "                  with_category=True, with_attributes=False, box_line_width=0, render_scale=2)"
    ]
   },
@@ -228,10 +231,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "nuim.render_image(sd_token_camera, with_category=True, object_tokens=[object_tokens[0]], surface_tokens=[surface_tokens[0]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get the raw data (i.e. the segmentation masks, both semantic and instance) of a render, we can use `get_segmentation()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "semantic_mask, instance_mask = nuim.get_segmentation(sd_token_camera)\n",
+    "\n",
+    "plt.figure(figsize=(32, 9))\n",
+    "\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(semantic_mask)\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(instance_mask)\n",
+    "\n",
+    "plt.show()"
    ]
   },
   {
@@ -284,7 +316,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    nuim.render_image(next_sd_token_camera, with_annotations=False)\n",
+    "    nuim.render_image(next_sd_token_camera, annotations_type=False)\n",
     "except Exception as e:\n",
     "    print('As expected, we encountered this error:', e)"
    ]
@@ -458,7 +490,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.list_attributes()"
+    "nuim.list_attributes(sort_by='freq')"
    ]
   },
   {
@@ -475,7 +507,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.list_cameras()"
+    "nuim.list_sensors()"
    ]
   }
  ],

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -50,9 +50,6 @@
     "%matplotlib inline\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "\n",
-    "import sys, os\n",
-    "sys.path.insert(0, os.path.expanduser('~/Desktop/quick/nuscenes-devkit/python-sdk'))\n",
     "from nuimages import NuImages\n",
     "\n",
     "nuim = NuImages(dataroot='/data/sets/nuimages', version='v1.0-mini', verbose=True, lazy=True)"

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nuim.render_image(sd_token_camera, annotations_type='all',\n",
+    "nuim.render_image(sd_token_camera, annotation_type='all',\n",
     "                  with_category=True, with_attributes=False, box_line_width=0, render_scale=2)"
    ]
   },
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the raw data (i.e. the segmentation masks, both semantic and instance) of a render, we can use `get_segmentation()`."
+    "To get the raw data (i.e. the segmentation masks, both semantic and instance) of the above, we can use `get_segmentation()`."
    ]
   },
   {
@@ -313,7 +313,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    nuim.render_image(next_sd_token_camera, annotations_type=False)\n",
+    "    nuim.render_image(next_sd_token_camera, annotation_type='none')\n",
     "except Exception as e:\n",
     "    print('As expected, we encountered this error:', e)"
    ]

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -59,6 +59,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lazy loading\n",
+    "\n",
+    "Initializing the NuImages instance above was very fast, as we did not actually load the tables. Rather, the class implements lazy loading that overwrites the internal `__getattr__()` function to load a table if it is not already stored in memory. This will become clearer later on in the Tables section where we access `category`; we will see the required table being loaded from disk (to disable such notifications, just set `verbose=False` when initializing the NuImages object). Furthermore lazy loading can be disabled with `lazy=False`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Tables\n",
     "\n",
     "As described above, the NuImages class holds several tables. Each table is a list of records, and each record is a dictionary. For example the first record of the category table is stored at:"
@@ -163,15 +172,6 @@
     "\n",
     "sd_token_lidar = sample['key_lidar_token']\n",
     "print(sd_token_lidar)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lazy loading\n",
-    "\n",
-    "Initializing the NuImages instance above was very fast, as we did not actually load the tables. Rather, the class implements lazy loading that overwrites the internal `__getattr__()` function to load a table if it is not already stored in memory. The moment we accessed `category`, we could see the table being loaded from disk. To disable such notifications, just set `verbose=False` when initializing the NuImages object. Furthermore lazy loading can be disabled with `lazy=False`."
    ]
   },
   {

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -187,7 +187,9 @@
     "- cones and barriers: black\n",
     "- driveable surface: teal / green\n",
     "\n",
-    "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object. Let us make the image bigger for better visibility by setting `render_scale=2`. We can also change the line width of the boxes using `box_line_width`. By setting it to 0, the line width adapts to the `render_scale`. Finally, we can rendering the image to disk using `out_path`."
+    "At the top left corner of each box, we see the name of the object category (if `with_category=True`). We can also set `with_attributes=True` to print the attributes of each object (note that we can only set `with_attributes=True` to print the attributes of each object when `with_category=True`). \n",
+    "\n",
+    "Let us make the image bigger for better visibility by setting `render_scale=2`. We can also change the line width of the boxes using `box_line_width`. By setting it to 0, the line width adapts to the `render_scale`. Finally, we can rendering the image to disk using `out_path`."
    ]
   },
   {

--- a/setup/Dockerfile_3.6
+++ b/setup/Dockerfile_3.6
@@ -15,6 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /nuscenes-dev
 COPY setup/requirements.txt /nuscenes-dev
+COPY setup/requirements/ /nuscenes-dev/setup/requirements/
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.6; source activate nuscenes && \
     pip install -r /nuscenes-dev/requirements.txt \

--- a/setup/Dockerfile_3.6
+++ b/setup/Dockerfile_3.6
@@ -14,9 +14,10 @@ RUN apt-get update && \
 
 
 WORKDIR /nuscenes-dev
+COPY setup/requirements.txt /nuscenes-dev
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.6; source activate nuscenes && \
-    pip install -r /nuscenes-dev/setup/requirements.txt \
+    pip install -r /nuscenes-dev/requirements.txt \
     && conda clean --yes --all"
 
 COPY . /nuscenes-dev

--- a/setup/Dockerfile_3.6
+++ b/setup/Dockerfile_3.6
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /nuscenes-dev
 COPY setup/requirements.txt /nuscenes-dev
-COPY setup/requirements/ /nuscenes-dev/setup/requirements/
+COPY setup/requirements/ /nuscenes-dev/requirements/
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.6; source activate nuscenes && \
     pip install -r /nuscenes-dev/requirements.txt \

--- a/setup/Dockerfile_3.6
+++ b/setup/Dockerfile_3.6
@@ -14,10 +14,9 @@ RUN apt-get update && \
 
 
 WORKDIR /nuscenes-dev
-COPY setup/requirements.txt /nuscenes-dev
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.6; source activate nuscenes && \
-    pip install -r /nuscenes-dev/requirements.txt \
+    pip install -r /nuscenes-dev/setup/requirements.txt \
     && conda clean --yes --all"
 
 COPY . /nuscenes-dev

--- a/setup/Dockerfile_3.7
+++ b/setup/Dockerfile_3.7
@@ -14,10 +14,9 @@ RUN apt-get update && \
 
 
 WORKDIR /nuscenes-dev
-COPY setup/requirements.txt /nuscenes-dev
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.7; source activate nuscenes && \
-    pip install -r /nuscenes-dev/requirements.txt \
+    pip install -r /nuscenes-dev/setup/requirements.txt \
     && conda clean --yes --all"
 
 COPY . /nuscenes-dev

--- a/setup/Dockerfile_3.7
+++ b/setup/Dockerfile_3.7
@@ -14,9 +14,10 @@ RUN apt-get update && \
 
 
 WORKDIR /nuscenes-dev
+COPY setup/requirements.txt /nuscenes-dev
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.7; source activate nuscenes && \
-    pip install -r /nuscenes-dev/setup/requirements.txt \
+    pip install -r /nuscenes-dev/requirements.txt \
     && conda clean --yes --all"
 
 COPY . /nuscenes-dev

--- a/setup/Dockerfile_3.7
+++ b/setup/Dockerfile_3.7
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /nuscenes-dev
 COPY setup/requirements.txt /nuscenes-dev
-COPY setup/requirements/ /nuscenes-dev/setup/requirements/
+COPY setup/requirements/ /nuscenes-dev/requirements/
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.7; source activate nuscenes && \
     pip install -r /nuscenes-dev/requirements.txt \

--- a/setup/Dockerfile_3.7
+++ b/setup/Dockerfile_3.7
@@ -15,6 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /nuscenes-dev
 COPY setup/requirements.txt /nuscenes-dev
+COPY setup/requirements/ /nuscenes-dev/setup/requirements/
 # Install Python dependencies inside of the Docker image via Conda.
 RUN bash -c "conda create -y -n nuscenes python=3.7; source activate nuscenes && \
     pip install -r /nuscenes-dev/requirements.txt \


### PR DESCRIPTION
### This PR will:
- Update the documentation (tutorial, readme, installation.md, etc.) in nuImages
- Allow the user to adjust the font size in `render_image`
- Allow the user to render only surfaces, only objects, both, or neither in `render_image`
- Introduce a method `get_segmentation` to allow the user to get both the semantic segmentation mask and instance segmentation mask