### PR TITLE
Loading large json files

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -2,6 +2,7 @@
 # Code written by Oscar Beijbom, 2018.
 
 import json
+import ijson
 import math
 import os.path as osp
 import sys

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -103,8 +103,8 @@ class NuScenes:
             if table_name == "sample_data":
                 table = []
                 data = ijson.items(f, 'item')
-                for post in data:
-                    table.append(post)
+                for inst in data:
+                    table.append(inst)
             else:
                 table = json.load(f)
         return table

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -99,7 +99,13 @@ class NuScenes:
     def __load_table__(self, table_name) -> dict:
         """ Loads a table. """
         with open(osp.join(self.table_root, '{}.json'.format(table_name))) as f:
-            table = json.load(f)
+            if table_name == "sample_data":
+                table = []
+                data = ijson.items(f, 'item')
+                for post in data:
+                    table.append(post)
+            else:
+                table = json.load(f)
         return table
 
     def __make_reverse_index__(self, verbose: bool) -> None:

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -15,3 +15,4 @@ Shapely
 torch>=1.3.1
 torchvision>=0.4.2
 tqdm
+ijson


### PR DESCRIPTION
I was trying to use devkit for trainval dataset and process was killed when it reached to self.__load_table__("sample_data") part. Turns out while reading large json files, machine runs out of memory. 

Using `ijson` package, which is a module that will work with JSON as a stream, rather than as a block file, instead of `json` library solved the issue.

I just applied it to `sample_data.json` file as it is the only file that causes problem, but this implementation can be applied for all of the files.