### PR TITLE
Align indices in nuImages and nuScenes-lidarseg

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -104,6 +104,10 @@ class NuScenes:
                 self.lidarseg_idx2name_mapping[lidarseg_category['index']] = lidarseg_category['name']
                 self.lidarseg_name2idx_mapping[lidarseg_category['name']] = lidarseg_category['index']
 
+            # Sort the colormap to ensure that it is ordered according to the indices in self.category.
+            self.colormap = dict({c['name']: self.colormap[c['name']]
+                                  for c in sorted(self.category, key=lambda k: k['index'])})
+
         # If available, also load the image_annotations table created by export_2d_annotations_as_json().
         if osp.exists(osp.join(self.table_root, 'image_annotations.json')):
             self.image_annotations = self.__load_table__('image_annotations')

--- a/python-sdk/nuscenes/utils/color_map.py
+++ b/python-sdk/nuscenes/utils/color_map.py
@@ -9,36 +9,36 @@ def get_colormap() -> Dict[str, Iterable[int]]:
 
     classname_to_color = {  # RGB.
         "noise": [0, 0, 0],  # Black.
+        "animal": [70, 130, 180],  # Steelblue
         "human.pedestrian.adult": [0, 0, 230],  # Blue
         "human.pedestrian.child": [135, 206, 235],  # Skyblue,
-        "human.pedestrian.wheelchair": [138, 43, 226],  # Blueviolet
-        "human.pedestrian.stroller": [240, 128, 128],  # Lightcoral
+        "human.pedestrian.construction_worker": [100, 149, 237],  # Cornflowerblue
         "human.pedestrian.personal_mobility": [219, 112, 147],  # Palevioletred
         "human.pedestrian.police_officer": [0, 0, 128],  # Navy,
-        "human.pedestrian.construction_worker": [100, 149, 237],  # Cornflowerblue
-        "animal": [70, 130, 180],  # Steelblue
-        "vehicle.car": [255, 158, 0],  # Orange
-        "vehicle.motorcycle": [255, 61, 99],  # Red
+        "human.pedestrian.stroller": [240, 128, 128],  # Lightcoral
+        "human.pedestrian.wheelchair": [138, 43, 226],  # Blueviolet
+        "movable_object.barrier": [112, 128, 144],  # Slategrey
+        "movable_object.debris": [210, 105, 30],  # Chocolate
+        "movable_object.pushable_pullable": [105, 105, 105],  # Dimgrey
+        "movable_object.trafficcone": [47, 79, 79],  # Darkslategrey
+        "static_object.bicycle_rack": [188, 143, 143],  # Rosybrown
         "vehicle.bicycle": [220, 20, 60],  # Crimson
         "vehicle.bus.bendy": [255, 127, 80],  # Coral
         "vehicle.bus.rigid": [255, 69, 0],  # Orangered
-        "vehicle.truck": [255, 99, 71],  # Tomato
+        "vehicle.car": [255, 158, 0],  # Orange
         "vehicle.construction": [233, 150, 70],  # Darksalmon
         "vehicle.emergency.ambulance": [255, 83, 0],
         "vehicle.emergency.police": [255, 215, 0],  # Gold
+        "vehicle.motorcycle": [255, 61, 99],  # Red
         "vehicle.trailer": [255, 140, 0],  # Darkorange
-        "movable_object.barrier": [112, 128, 144],  # Slategrey
-        "movable_object.trafficcone": [47, 79, 79],  # Darkslategrey
-        "movable_object.pushable_pullable": [105, 105, 105],  # Dimgrey
-        "movable_object.debris": [210, 105, 30],  # Chocolate
-        "static_object.bicycle_rack": [188, 143, 143],  # Rosybrown
+        "vehicle.truck": [255, 99, 71],  # Tomato
         "flat.driveable_surface": [0, 207, 191],  # nuTonomy green
+        "flat.other": [175, 0, 75],
         "flat.sidewalk": [75, 0, 75],
         "flat.terrain": [112, 180, 60],
-        "flat.other": [175, 0, 75],
         "static.manmade": [222, 184, 135],  # Burlywood
-        "static.vegetation": [0, 175, 0],  # Green
         "static.other": [255, 228, 196],  # Bisque
+        "static.vegetation": [0, 175, 0],  # Green
         "vehicle.ego": [255, 240, 245]
     }
 


### PR DESCRIPTION
### This PR will:
- Re-order the colormap such that each class name is assigned an index by alphabetical order (except `noise` and `vehicle.ego`); the updated order of the classes will be:
```
noise
animal
human.pedestrian.adult
human.pedestrian.child
human.pedestrian.construction_worker
human.pedestrian.personal_mobility
human.pedestrian.police_officer
human.pedestrian.stroller
human.pedestrian.wheelchair
movable_object.barrier
movable_object.debris
movable_object.pushable_pullable
movable_object.trafficcone
static_object.bicycle_rack
vehicle.bicycle
vehicle.bus.bendy
vehicle.bus.rigid
vehicle.car
vehicle.construction
vehicle.emergency.ambulance
vehicle.emergency.police
vehicle.motorcycle
vehicle.trailer
vehicle.truck
flat.driveable_surface
flat.other
flat.sidewalk
flat.terrain
static.manmade
static.other
static.vegetation
vehicle.ego
```