### PR TITLE
nuScenes tutorials in Google Colab

### DIFF
--- a/python-sdk/tutorials/README.md
+++ b/python-sdk/tutorials/README.md
@@ -1,0 +1,4 @@
+# Tutorials
+This folder contains all the tutorials for the devkit of the [nuScenes](https://www.nuscenes.org/nuscenes) and [nuImages](https://www.nuscenes.org/nuimages) datasets.
+
+All the tutorials are also [available on Google Colab](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/).

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -38,7 +38,13 @@
    "metadata": {},
    "source": [
     "## Google Colab (optional)\n",
-    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuimages_tutorial.ipynb)\n",
+    "\n",
+    "<br>\n",
+    "<a href=\"https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb\">\n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\" align=\"left\">\n",
+    "</a>\n",
+    "<br>\n",
+    "    \n",
     "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, manually set up everything."
    ]
   },

--- a/python-sdk/tutorials/nuimages_tutorial.ipynb
+++ b/python-sdk/tutorials/nuimages_tutorial.ipynb
@@ -37,6 +37,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Google Colab (optional)\n",
+    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuimages_tutorial.ipynb)\n",
+    "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, manually set up everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !mkdir -p /data/sets/nuimages  # Make the directory to store the nuImages dataset in.\n",
+    "\n",
+    "# !wget https://www.nuscenes.org/data/nuimages-v1.0-mini.tgz  # Download the nuImages mini split.\n",
+    "\n",
+    "# !tar -xf nuimages-v1.0-mini.tgz -C /data/sets/nuimages  # Uncompress the nuImages mini split.\n",
+    "\n",
+    "# !pip install nuscenes-devkit &> /dev/null  # Install nuImages."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Initialization\n",
     "To initialize the dataset class, we run the code below. We can change the dataroot parameter if the dataset is installed in a different folder. We can also omit it to use the default setup. These will be useful further below."
    ]
@@ -488,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -15,32 +15,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Google Colab (optional) \n",
-    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb)\n",
-    "If you are running this notebook in Google Colab, you can uncomment the below cell and run it; everything will be set up nicely for you within Google Colab. Otherwise, go to [**Setup**](#Setup) to manually set up everything."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# !mkdir -p /data/sets/nuscenes  # Make the directory to store the nuScenes dataset in.\n",
-    "\n",
-    "# !wget https://www.nuscenes.org/data/v1.0-mini.tgz  # Download the nuScenes mini split.\n",
-    "# !wget https://www.nuscenes.org/data/nuScenes-lidarseg-mini-v1.0.tar.bz2  # Download the nuScenes-lidarseg mini split.\n",
-    "\n",
-    "# !tar -xf v1.0-mini.tgz -C /data/sets/nuscenes  # Uncompress the nuScenes mini split.\n",
-    "# !tar -xf nuScenes-lidarseg-mini-v1.0.tar.bz2 -C /data/sets/nuscenes   # Uncompress the nuScenes-lidarseg mini split.\n",
-    "\n",
-    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Setup\n",
     "To install the nuScenes-lidarseg expansion, download the dataset from https://www.nuscenes.org/download. Unpack the compressed file(s) into `/data/sets/nuscenes` and your folder structure should end up looking like this:\n",
     "```\n",
@@ -58,6 +32,32 @@
     "        └── category.json  <- contains the categories of the labels (note that the \n",
     "                              category.json from nuScenes v1.0 is overwritten)\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Google Colab (optional) \n",
+    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb)\n",
+    "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, go to [**Setup**](#Setup) to manually set up everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !mkdir -p /data/sets/nuscenes  # Make the directory to store the nuScenes dataset in.\n",
+    "\n",
+    "# !wget https://www.nuscenes.org/data/v1.0-mini.tgz  # Download the nuScenes mini split.\n",
+    "# !wget https://www.nuscenes.org/data/nuScenes-lidarseg-mini-v1.0.tar.bz2  # Download the nuScenes-lidarseg mini split.\n",
+    "\n",
+    "# !tar -xf v1.0-mini.tgz -C /data/sets/nuscenes  # Uncompress the nuScenes mini split.\n",
+    "# !tar -xf nuScenes-lidarseg-mini-v1.0.tar.bz2 -C /data/sets/nuscenes   # Uncompress the nuScenes-lidarseg mini split.\n",
+    "\n",
+    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes"
    ]
   },
   {
@@ -492,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -15,6 +15,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Google Colab (optional)\n",
+    "If you are running this notebook in Google Colab, you can uncomment the below cell and run it; everything will be set up nicely for you within Google Colab. Otherwise, go to [**Setup**](#Setup) to manually set up everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !mkdir -p /data/sets/nuscenes  # Make the directory to store the nuScenes dataset in.\n",
+    "\n",
+    "# !wget https://www.nuscenes.org/data/v1.0-mini.tgz  # Download the nuScenes mini split.\n",
+    "# !wget https://www.nuscenes.org/data/nuScenes-lidarseg-mini-v1.0.tar.bz2  # Download the nuScenes-lidarseg mini split.\n",
+    "\n",
+    "# !tar -xf v1.0-mini.tgz -C /data/sets/nuscenes  # Uncompress the nuScenes mini split.\n",
+    "# !tar -xf nuScenes-lidarseg-mini-v1.0.tar.bz2 -C /data/sets/nuscenes   # Uncompress the nuScenes-lidarseg mini split.\n",
+    "\n",
+    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Setup\n",
     "To install the nuScenes-lidarseg expansion, download the dataset from https://www.nuscenes.org/download. Unpack the compressed file(s) into `/data/sets/nuscenes` and your folder structure should end up looking like this:\n",
     "```\n",

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -15,7 +15,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Google Colab (optional)\n",
+    "## Google Colab (optional) \n",
+    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb)\n",
     "If you are running this notebook in Google Colab, you can uncomment the below cell and run it; everything will be set up nicely for you within Google Colab. Otherwise, go to [**Setup**](#Setup) to manually set up everything."
    ]
   },

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -57,7 +57,7 @@
     "# !tar -xf v1.0-mini.tgz -C /data/sets/nuscenes  # Uncompress the nuScenes mini split.\n",
     "# !tar -xf nuScenes-lidarseg-mini-v1.0.tar.bz2 -C /data/sets/nuscenes   # Uncompress the nuScenes-lidarseg mini split.\n",
     "\n",
-    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes"
+    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes."
    ]
   },
   {

--- a/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb
@@ -39,7 +39,13 @@
    "metadata": {},
    "source": [
     "## Google Colab (optional) \n",
-    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_lidarseg_tutorial.ipynb)\n",
+    "\n",
+    "<br>\n",
+    "<a href=\"https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb\">\n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/ align=\"left\">\n",
+    "</a>\n",
+    "<br>\n",
+    "\n",
     "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, go to [**Setup**](#Setup) to manually set up everything."
    ]
   },

--- a/python-sdk/tutorials/nuscenes_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_tutorial.ipynb
@@ -39,6 +39,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Google Colab (optional)\n",
+    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb)\n",
+    "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, manually set up everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !mkdir -p /data/sets/nuscenes  # Make the directory to store the nuScenes dataset in.\n",
+    "\n",
+    "# !wget https://www.nuscenes.org/data/v1.0-mini.tgz  # Download the nuScenes mini split.\n",
+    "\n",
+    "# !tar -xf v1.0-mini.tgz -C /data/sets/nuscenes  # Uncompress the nuScenes mini split.\n",
+    "\n",
+    "# !pip install nuscenes-devkit &> /dev/null  # Install nuScenes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Initialization"
    ]
   },
@@ -1299,7 +1323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/python-sdk/tutorials/nuscenes_tutorial.ipynb
+++ b/python-sdk/tutorials/nuscenes_tutorial.ipynb
@@ -40,7 +40,13 @@
    "metadata": {},
    "source": [
     "## Google Colab (optional)\n",
-    "[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb)\n",
+    "\n",
+    "<br>\n",
+    "<a href=\"https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb\">\n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\" align=\"left\">\n",
+    "</a>\n",
+    "<br>\n",
+    "\n",
     "If you are running this notebook in Google Colab, you can uncomment the cell below and run it; everything will be set up nicely for you. Otherwise, manually set up everything."
    ]
   },


### PR DESCRIPTION
### This PR will:
- Update the nuScenes tutorials so that they can be run in Colab, if the user desires; as an example: https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/tutorial_colab/python-sdk/tutorials/nuscenes_tutorial.ipynb