### PR TITLE
Do not return more than 2 * sec annotations when iterating...

### DIFF
--- a/python-sdk/nuscenes/prediction/helper.py
+++ b/python-sdk/nuscenes/prediction/helper.py
@@ -138,7 +138,9 @@ class PredictHelper:
 
         annotations = []
 
-        while time_elapsed <= seconds_with_buffer:
+        expected_samples_per_sec = 2
+        max_annotations = int(expected_samples_per_sec * seconds)
+        while time_elapsed <= seconds_with_buffer and len(annotations) < max_annotations:
 
             if next_annotation[direction] == '':
                 break


### PR DESCRIPTION
**Issue**: https://github.com/nutonomy/nuscenes-devkit/issues/472

**Changes**
- Put an upper limit on the number of annotations returned when querying past or future based on expected frequency and seconds requested

**Known Issues**
@holger-nutonomy Is 2 Hz a variable anywhere that I can use? I did a quick search, but could not find