### PR TITLE
Remove torch/motmetrics/pandas requirements and skip related tests

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,9 @@ Download the devkit to your home directory using:
 ```
 cd && git clone https://github.com/nutonomy/nuscenes-devkit.git
 ```
+*Note:* The pip package does not support the prediction or tracking code.
+For these, you will need to download the source code and [manually install the requirements](#install-required-packages).
+
 ## Install Python
 
 The devkit is tested for Python 3.6 onwards, but we recommend to use Python 3.7.
@@ -104,7 +107,12 @@ To install the required packages, run the following command in your favourite vi
 ```
 pip install -r setup/requirements.txt
 ```
-**Note:** The requirements file is internally divided into base requirements (`base`) and requirements specific to certain products or challenges (`nuimages`, `prediction` and `tracking`). If you only plan to use a subset of the codebase, feel free to comment out the lines that you do not need.
+**Note:** The requirements file is internally divided into base requirements (`base`) and requirements specific to certain products or challenges (`nuimages`, `prediction` and `tracking`).
+From December 2020 onwards we are excluding the `prediction` and `tracking` requirements by default to decrease the number of packages that are installed and avoid incompatibility with other pip packages.
+If you want to install these requirements nevertheless, please run the following for `prediction` (and analog for `tracking`):
+```
+pip install -r setup/requirements/requirements_prediction.txt
+``` 
 
 ## Setup environment variable
 Finally, if you want to run the unit tests you need to point the devkit to the `nuscenes` folder on your disk.

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -12,11 +12,16 @@ https://github.com/cheind/py-motmetrics
 """
 import os
 from typing import List, Dict, Callable, Tuple
+import unittest
 
 import numpy as np
-import pandas
 import sklearn
 import tqdm
+
+try:
+    import pandas
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as pandas was not found!')
 
 from nuscenes.eval.tracking.constants import MOT_METRIC_MAP, TRACKING_METRICS
 from nuscenes.eval.tracking.data_classes import TrackingBox, TrackingMetricData

--- a/python-sdk/nuscenes/eval/tracking/utils.py
+++ b/python-sdk/nuscenes/eval/tracking/utils.py
@@ -1,12 +1,17 @@
 # nuScenes dev-kit.
 # Code written by Holger Caesar, 2019.
 
+import unittest
 import warnings
 from typing import Optional, Dict
 
-import motmetrics
 import numpy as np
-from motmetrics.metrics import MetricsHost
+
+try:
+    import motmetrics
+    from motmetrics.metrics import MetricsHost
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as motmetrics was not found!')
 
 from nuscenes.eval.tracking.data_classes import TrackingMetrics
 from nuscenes.eval.tracking.metrics import motar, mota_custom, motp_custom, faf, track_initialization_duration, \

--- a/python-sdk/nuscenes/map_expansion/tests/test_all_maps.py
+++ b/python-sdk/nuscenes/map_expansion/tests/test_all_maps.py
@@ -68,7 +68,7 @@ class TestAllMaps(unittest.TestCase):
         whitelist = ['scene-0499', 'scene-0501', 'scene-0502', 'scene-0515', 'scene-0517']
 
         invalid_scenes = []
-        for scene in tqdm.tqdm(nusc.scene):
+        for scene in tqdm.tqdm(nusc.scene, leave=False):
             if scene['name'] in whitelist:
                 continue
 

--- a/python-sdk/nuscenes/prediction/tests/test_backbone.py
+++ b/python-sdk/nuscenes/prediction/tests/test_backbone.py
@@ -1,7 +1,10 @@
 import unittest
 
-import torch
-from torchvision.models.resnet import BasicBlock, Bottleneck
+try:
+    import torch
+    from torchvision.models.resnet import BasicBlock, Bottleneck
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as torch was not found!')
 
 from nuscenes.prediction.models.backbone import ResNetBackbone, MobileNetBackbone
 

--- a/python-sdk/nuscenes/prediction/tests/test_covernet.py
+++ b/python-sdk/nuscenes/prediction/tests/test_covernet.py
@@ -4,8 +4,11 @@
 import math
 import unittest
 
-import torch
-from torch.nn.functional import cross_entropy
+try:
+    import torch
+    from torch.nn.functional import cross_entropy
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as torch was not found!')
 
 from nuscenes.prediction.models.backbone import ResNetBackbone
 from nuscenes.prediction.models.covernet import mean_pointwise_l2_distance, ConstantLatticeLoss, CoverNet

--- a/python-sdk/nuscenes/prediction/tests/test_mtp.py
+++ b/python-sdk/nuscenes/prediction/tests/test_mtp.py
@@ -1,6 +1,9 @@
 import unittest
 
-import torch
+try:
+    import torch
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as torch was not found!')
 
 from nuscenes.prediction.models import backbone
 from nuscenes.prediction.models import mtp

--- a/python-sdk/nuscenes/prediction/tests/test_mtp_loss.py
+++ b/python-sdk/nuscenes/prediction/tests/test_mtp_loss.py
@@ -2,7 +2,10 @@
 import math
 import unittest
 
-import torch
+try:
+    import torch
+except ModuleNotFoundError:
+    raise unittest.SkipTest('Skipping test as torch was not found!')
 
 from nuscenes.prediction.models import mtp
 

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,4 +1,4 @@
 -r requirements/requirements_base.txt
--r requirements/requirements_prediction.txt
--r requirements/requirements_tracking.txt
 -r requirements/requirements_nuimages.txt
+# -r requirements/requirements_prediction.txt  # Uncomment this for the prediction code
+# -r requirements/requirements_tracking.txt  # Uncomment this for the tracking code


### PR DESCRIPTION
This PR removes the tracking and prediction requirements from the default nuscenes-devkit installation. They can still be installed manually. The major implication of this is that all unit test which require these packages *would* fail. We therefore catch `ModuleNotFoundErrors` when importing the modules `torch`, `motmetrics` and `pandas`.

Here is the test output *without* those requirements installed:
```
...........................ssss.............................................................................
----------------------------------------------------------------------
Ran 179 tests in 21.658s
```
Here is the test output *with* those requirements installed:
```
...........................................................................................................................
----------------------------------------------------------------------
Ran 203 tests in 36.815s

OK

```