### PR TITLE
Specify PIL version to be > 6.2.1

### DIFF
--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -5,7 +5,7 @@ jupyter
 matplotlib
 numpy
 opencv-python
-Pillow
+Pillow>6.2.1
 pyquaternion>=0.9.5
 scikit-learn
 scipy


### PR DESCRIPTION
The `nuscenes-devkit` package was using PIL version `<= 6.2.1` and for some reason PIL imports were breaking for that PIL version. In this PR, the `requirements.txt` is updated to ensure that the PIL version is `> 6.2.1`.