### PR TITLE
Fixed Database not found error

### DIFF
--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -81,8 +81,10 @@ class KittiConverter:
             os.makedirs(self.nusc_kitti_dir)
 
         # Select subset of the data to look at.
-        self.nusc = NuScenes(datastore='path_of_data',version=nusc_version) # add datastore='path of the dataset' 
-        # ( Preferred Location - /home/user_name/sets/data/nuscenes and put all the folders here.
+        self.nusc = NuScenes(version=nusc_version) 
+        """ If you get error - Database not found v1.0-mini, then add datastore='path of the dataset'
+            that is, self.nusc = NuScenes(datastore='path_of_dataset', version=nusc_version)
+            Example , datastore='/home/user_name/sets/data/nuscenes' and put all the extracted folders here ) """
 
     def nuscenes_gt_to_kitti(self) -> None:
         """

--- a/python-sdk/nuscenes/scripts/export_kitti.py
+++ b/python-sdk/nuscenes/scripts/export_kitti.py
@@ -81,7 +81,8 @@ class KittiConverter:
             os.makedirs(self.nusc_kitti_dir)
 
         # Select subset of the data to look at.
-        self.nusc = NuScenes(version=nusc_version)
+        self.nusc = NuScenes(datastore='path_of_data',version=nusc_version) # add datastore='path of the dataset' 
+        # ( Preferred Location - /home/user_name/sets/data/nuscenes and put all the folders here.
 
     def nuscenes_gt_to_kitti(self) -> None:
         """


### PR DESCRIPTION
When I was trying to convert nuScenes dataset to Kitti format, I was getting error - Database not found v1.0-mini. Then I figured out that while creating object of NuScenes, we have to pass the path where the extracted data is stored in the local machine. Hence was then able to work with the script.
So I just added few comment on how to resolve it incase someone gets the error.