### PR TITLE
Fix multisweep dtype

### DIFF
--- a/python-sdk/nuscenes/utils/data_classes.py
+++ b/python-sdk/nuscenes/utils/data_classes.py
@@ -73,7 +73,7 @@ class PointCloud(ABC):
         :return: (all_pc, all_times). The aggregated point cloud and timestamps.
         """
         # Init.
-        points = np.zeros((cls.nbr_dims(), 0))
+        points = np.zeros((cls.nbr_dims(), 0), dtype=np.float32)
         all_pc = cls(points)
         all_times = np.zeros((1, 0))
 
@@ -126,6 +126,9 @@ class PointCloud(ABC):
                 break
             else:
                 current_sd_rec = nusc.get('sample_data', current_sd_rec['prev'])
+
+        # Check that the multisweep pointcloud has the same dtype as individual pointclouds.
+        assert all_pc.points.dtype == np.float32
 
         return all_pc, all_times
 

--- a/python-sdk/nuscenes/utils/data_classes.py
+++ b/python-sdk/nuscenes/utils/data_classes.py
@@ -128,7 +128,7 @@ class PointCloud(ABC):
                 current_sd_rec = nusc.get('sample_data', current_sd_rec['prev'])
 
         # Check that the multisweep pointcloud has the same dtype as individual pointclouds.
-        assert all_pc.points.dtype == np.float32
+        assert all_pc.points.dtype == np.float32, 'Error: Invalid dtype for multisweep pointcloud!'
 
         return all_pc, all_times
 


### PR DESCRIPTION
As pointed out in https://forum.nuscenes.org/t/fusing-lidar-sweeps-with-keyframe/533/9, the functions `from_file_multisweep` and `from_file` in `LidarPointCloud` do not return a point cloud of the same dtype, but rather use float64 vs. float32. This means that the export_kitti script can run into problems when modified to use this function.
This PR fixes that by forcing `from_file_multisweep` to return a float32 array.