### PR TITLE
Avoid unittest skipping in detection eval

### DIFF
--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -13,7 +13,6 @@ from nuscenes.eval.common.data_classes import EvalBoxes
 from nuscenes.eval.detection.data_classes import DetectionBox
 from nuscenes.eval.detection.utils import category_to_detection_name
 from nuscenes.eval.tracking.data_classes import TrackingBox
-from nuscenes.eval.tracking.utils import category_to_tracking_name
 from nuscenes.utils.data_classes import Box
 from nuscenes.utils.geometry_utils import points_in_box
 from nuscenes.utils.splits import create_splits_scenes
@@ -148,6 +147,8 @@ def load_gt(nusc: NuScenes, eval_split: str, box_cls, verbose: bool = False) -> 
                 tracking_id_set.add(tracking_id)
 
                 # Get label name in detection task and filter unused labels.
+                # Import locally to avoid errors when motmetrics package is not installed.
+                from nuscenes.eval.tracking.utils import category_to_tracking_name
                 tracking_name = category_to_tracking_name(sample_annotation['category_name'])
                 if tracking_name is None:
                     continue


### PR DESCRIPTION
Currently the detection eval code has an import dependency on some of the tracking code. Hence, if the motmetrics package of the tracking code is not available, all third party unit tests that use the detection code will be skipped. This PR works around that by only importing the package inside the relevant function.