### PR TITLE
Pip package 1.1.4, replace legacy float format

### DIFF
--- a/python-sdk/nuscenes/eval/detection/algo.py
+++ b/python-sdk/nuscenes/eval/detection/algo.py
@@ -124,8 +124,8 @@ def accumulate(gt_boxes: EvalBoxes,
     # ---------------------------------------------
 
     # Accumulate.
-    tp = np.cumsum(tp).astype(np.float)
-    fp = np.cumsum(fp).astype(np.float)
+    tp = np.cumsum(tp).astype(float)
+    fp = np.cumsum(fp).astype(float)
     conf = np.array(conf)
 
     # Calculate precision and recall.

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -39,7 +39,7 @@ packages = [p for p in packages if not p.endswith('__pycache__')]
 
 setuptools.setup(
     name='nuscenes-devkit',
-    version='1.1.3',
+    version='1.1.4',
     author='Holger Caesar, Oscar Beijbom, Qiang Xu, Varun Bankiti, Alex H. Lang, Sourabh Vora, Venice Erin Liong, '
            'Sergi Widjaja, Kiwoo Shin, Caglayan Dicle, Freddy Boulton, Whye Kit Fong, Asha Asvathaman et al.',
     author_email='nuscenes@motional.com',


### PR DESCRIPTION
- Bump pip version to 1.1.4 following previous changes to how tests work: https://github.com/nutonomy/nuscenes-devkit/commit/bfb57a4e5b044a9f448a3412b23966821f695aaf
- Replace legacy float format to avoid deprecation warnings in numpy