### PR TITLE
Bump pip version to 1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Welcome to the devkit of the [nuScenes](https://www.nuscenes.org/nuscenes) and [
 - [Citation](#citation)
 
 ## Changelog
-- Jul. 29, 2020: Devkit v1.2.0: nuScenes-panoptic v1.0 code, NeurIPS challenge announcement.
+- Jul. 29, 2020: Devkit v1.1.6: nuScenes-panoptic v1.0 code, NeurIPS challenge announcement.
 - Apr. 5, 2021: Devkit v1.1.3: Bug fixes and pip requirements.
 - Nov. 23, 2020: Devkit v1.1.2: Release map-expansion v1.3 with lidar basemap.
 - Nov. 9, 2020: Devkit v1.1.1: Lidarseg evaluation code, NeurIPS challenge announcement.

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -39,9 +39,10 @@ packages = [p for p in packages if not p.endswith('__pycache__')]
 
 setuptools.setup(
     name='nuscenes-devkit',
-    version='1.1.5',
+    version='1.1.6',
     author='Holger Caesar, Oscar Beijbom, Qiang Xu, Varun Bankiti, Alex H. Lang, Sourabh Vora, Venice Erin Liong, '
-           'Sergi Widjaja, Kiwoo Shin, Caglayan Dicle, Freddy Boulton, Whye Kit Fong, Asha Asvathaman et al.',
+           'Sergi Widjaja, Kiwoo Shin, Caglayan Dicle, Freddy Boulton, Whye Kit Fong, Asha Asvathaman, Lubing Zhou '
+           'et al.',
     author_email='nuscenes@motional.com',
     description='The official devkit of the nuScenes dataset (www.nuscenes.org).',
     long_description=long_description,


### PR DESCRIPTION
### This PR will:
- Bump the pip version for the nuscenes-devkit to `1.1.6`
- Extend the list of authors given the introduction of nuScenes-panoptic 