### PR TITLE
Update print statement in filter_eval_boxes to say that points-based filtering is done based on sum of lidar and radar points

### DIFF
--- a/python-sdk/nuscenes/eval/common/loaders.py
+++ b/python-sdk/nuscenes/eval/common/loaders.py
@@ -255,7 +255,7 @@ def filter_eval_boxes(nusc: NuScenes,
     if verbose:
         print("=> Original number of boxes: %d" % total)
         print("=> After distance based filtering: %d" % dist_filter)
-        print("=> After LIDAR points based filtering: %d" % point_filter)
+        print("=> After LIDAR and RADAR points based filtering: %d" % point_filter)
         print("=> After bike rack filtering: %d" % bike_rack_filter)
 
     return eval_boxes


### PR DESCRIPTION
### This PR will:
- Update print statement in `filter_eval_boxes` to say that points-based filtering is done based on sum of lidar and radar points (see https://github.com/nutonomy/nuscenes-devkit/issues/625 for details)