### PR TITLE
Panoptic labels generation fix

### DIFF
--- a/python-sdk/nuscenes/eval/panoptic/README.md
+++ b/python-sdk/nuscenes/eval/panoptic/README.md
@@ -207,7 +207,7 @@ different segments.
 
 ### Multi-Object Panoptic Tracking
 #### Panoptic Tracking Quality (PTQ)
-We use PTQ [Juana et al.](https://arxiv.org/pdf/2004.08189.pdf) that extends PQ with the IoU of matched segments with
+We use PTQ [Hurtado et al.](https://arxiv.org/pdf/2004.08189.pdf) that extends PQ with the IoU of matched segments with
 track ID discrepancy, penalizing the incorrect track predictions. PTQ is defined as
 (∑{**1**(p,g) IoU(p,g)} - |IDS|) / (|TP|+ 0.5|FP|+ 0.5|FN|), where IDS stands for ID switches, and it is computed as
 the number of true positives (TP) that differ between tracking prediction and ground truth.

--- a/python-sdk/nuscenes/panoptic/generate_panoptic_labels.py
+++ b/python-sdk/nuscenes/panoptic/generate_panoptic_labels.py
@@ -74,6 +74,8 @@ def generate_panoptic_labels(nusc: NuScenes, out_dir: str, verbose: bool = False
         panop_labels[overlap_box_count > 1] = 0  # Set pixels overlapped by > 1 boxes to 0.
 
         # Thing pixels that are not inside any box have instance id == 0, reset them to 0.
+        # For these pixels that have thing semantic classes, but do not fall inside any annotation box, set their
+        # panoptic label to 0.
         semantic_labels = panop_labels // 1000
         thing_mask = np.logical_and(semantic_labels > 0, semantic_labels < STUFF_START_CLASS_ID)
         pixels_wo_box = np.logical_and(thing_mask, panop_labels % 1000 == 0)


### PR DESCRIPTION
There is a bug in the panoptic labels generation. For these thing category points that not belongs to (inside) any annotated boxes, their values will be lidarseg * 1000 rather than the expected 0.  In panoptic evaluation, the impact is these pixels will be treated as an instance with instance_id = 0, panoptic class  = lidarseg class. This PR is to reset their panoptic labels to 0.