### PR TITLE
 Extend lidarseg plot to plot histograms for both number of points and number of scan-wise instances per class

### DIFF
--- a/python-sdk/nuscenes/lidarseg/class_histogram.py
+++ b/python-sdk/nuscenes/lidarseg/class_histogram.py
@@ -1,14 +1,15 @@
 import os
-import time
-from typing import List, Tuple
+from typing import Dict
 
 import matplotlib.pyplot as plt
-from matplotlib.ticker import FuncFormatter, ScalarFormatter
+import matplotlib.ticker as mticker
 import matplotlib.transforms as mtrans
 import numpy as np
 
 from nuscenes import NuScenes
+from nuscenes.panoptic.panoptic_utils import get_frame_panoptic_instances, get_panoptic_instances_stats
 from nuscenes.utils.color_map import get_colormap
+from nuscenes.utils.data_io import load_bin_file
 
 
 def truncate_class_name(class_name: str) -> str:
@@ -56,15 +57,11 @@ def truncate_class_name(class_name: str) -> str:
     return string_mapper[class_name]
 
 
-def render_lidarseg_histogram(nusc: NuScenes,
-                              sort_by: str = 'count_desc',
-                              chart_title: str = None,
-                              x_label: str = None,
-                              y_label: str = "Lidar points (logarithmic)",
-                              y_log_scale: bool = True,
-                              verbose: bool = True,
-                              font_size: int = 20,
-                              save_as_img_name: str = None) -> None:
+def render_histogram(nusc: NuScenes,
+                     sort_by: str = 'count_desc',
+                     verbose: bool = True,
+                     font_size: int = 20,
+                     save_as_img_name: str = None) -> None:
     """
     Render a histogram for the given nuScenes split.
     :param nusc: A nuScenes object.
@@ -73,23 +70,42 @@ def render_lidarseg_histogram(nusc: NuScenes,
         - count_asc: Sort the classes by the number of points belonging to each class, in ascending order.
         - name: Sort the classes by alphabetical order.
         - index: Sort the classes by their indices.
-    :param chart_title: Title to display on the histogram.
-    :param x_label: Title to display on the x-axis of the histogram.
-    :param y_label: Title to display on the y-axis of the histogram.
-    :param y_log_scale: Whether to use log scale on the y-axis.
     :param verbose: Whether to display plot in a window after rendering.
     :param font_size: Size of the font to use for the histogram.
     :param save_as_img_name: Path (including image name and extension) to save the histogram as.
     """
 
-    print('Calculating stats for nuScenes-lidarseg...')
-    start_time = time.time()
-
     # Get the statistics for the given nuScenes split.
-    class_names, counts = get_lidarseg_stats(nusc, sort_by=sort_by)
+    lidarseg_num_points_per_class = get_lidarseg_num_points_per_class(nusc, sort_by=sort_by)
+    panoptic_num_instances_per_class = get_panoptic_num_instances_per_class(nusc, sort_by=sort_by)
 
-    print('Calculated stats for {} point clouds in {:.1f} seconds.\n====='.format(
-        len(nusc.lidarseg), time.time() - start_time))
+    # Align the two dictionaries by adding entries for the stuff classes to panoptic_num_instances_per_class; the
+    # instance count for each of these stuff classes is 0.
+    panoptic_num_instances_per_class_tmp = dict()
+    for class_name in lidarseg_num_points_per_class.keys():
+        num_instances_for_class = panoptic_num_instances_per_class.get(class_name, 0)
+        panoptic_num_instances_per_class_tmp[class_name] = num_instances_for_class
+    panoptic_num_instances_per_class = panoptic_num_instances_per_class_tmp
+
+    # Define some settings for each histogram.
+    histograms_config = dict({
+        'panoptic': {
+            'y_values': list(panoptic_num_instances_per_class.values()),
+            'y_label': 'No. of instances (log)',
+            'y_scale': 'log'
+        },
+        'lidarseg': {
+            'y_values': list(lidarseg_num_points_per_class.values()),
+            'y_label': 'No. of lidar points (log)',
+            'y_scale': 'log'
+        }
+    })
+
+    # Ensure the same set of class names are used for all histograms.
+    assert lidarseg_num_points_per_class.keys() == panoptic_num_instances_per_class.keys(), \
+        'Error: There are {} classes for lidarseg, but {} classes for panoptic.'.format(
+            len(lidarseg_num_points_per_class.keys()), len(panoptic_num_instances_per_class.keys()))
+    class_names = list(lidarseg_num_points_per_class.keys())
 
     # Create an array with the colors to use.
     cmap = get_colormap()
@@ -99,49 +115,42 @@ def render_lidarseg_histogram(nusc: NuScenes,
     class_names = [truncate_class_name(cn) for cn in class_names]
 
     # Start a plot.
-    fig, ax = plt.subplots(figsize=(16, 9))
-    plt.margins(x=0.005)  # Add some padding to the left and right limits of the x-axis for aesthetics.
-    ax.set_axisbelow(True)  # Ensure that axis ticks and gridlines will be below all other ploy elements.
-    ax.yaxis.grid(color='white', linewidth=2)  # Show horizontal gridlines.
-    ax.set_facecolor('#eaeaf2')  # Set background of plot.
-    ax.spines['top'].set_visible(False)  # Remove top border of plot.
-    ax.spines['right'].set_visible(False)  # Remove right border of plot.
-    ax.spines['bottom'].set_visible(False)  # Remove bottom border of plot.
-    ax.spines['left'].set_visible(False)  # Remove left border of plot.
+    fig, axes = plt.subplots(nrows=2, sharex=True, figsize=(16, 9))
+    for ax in axes:
+        ax.margins(x=0.005)  # Add some padding to the left and right limits of the x-axis for aesthetics.
+        ax.set_axisbelow(True)  # Ensure that axis ticks and gridlines will be below all other ploy elements.
+        ax.yaxis.grid(color='white', linewidth=2)  # Show horizontal gridlines.
+        ax.set_facecolor('#eaeaf2')  # Set background of plot.
+        ax.spines['top'].set_visible(False)  # Remove top border of plot.
+        ax.spines['right'].set_visible(False)  # Remove right border of plot.
+        ax.spines['bottom'].set_visible(False)  # Remove bottom border of plot.
+        ax.spines['left'].set_visible(False)  # Remove left border of plot.
 
-    # Plot the histogram.
-    ax.bar(class_names, counts, color=colors)
-    assert len(class_names) == len(ax.get_xticks()), \
-        'There are {} classes, but {} are shown on the x-axis'.format(len(class_names), len(ax.get_xticks()))
+    # Plot the histograms.
+    for i, (histogram, config) in enumerate(histograms_config.items()):
+        axes[i].bar(class_names, config['y_values'], color=colors)
+        assert len(class_names) == len(axes[i].get_xticks()), \
+            'There are {} classes, but {} are shown on the x-axis'.format(len(class_names), len(axes[i].get_xticks()))
 
-    # Format the x-axis.
-    ax.set_xlabel(x_label, fontsize=font_size)
-    ax.set_xticklabels(class_names, rotation=45, horizontalalignment='right',
-                       fontweight='light', fontsize=font_size)
+        # Format the x-axis.
+        axes[i].set_xticklabels(class_names, rotation=45, horizontalalignment='right',
+                                fontweight='light', fontsize=font_size)
 
-    # Shift the class names on the x-axis slightly to the right for aesthetics.
-    trans = mtrans.Affine2D().translate(10, 0)
-    for t in ax.get_xticklabels():
-        t.set_transform(t.get_transform() + trans)
+        # Shift the class names on the x-axis slightly to the right for aesthetics.
+        trans = mtrans.Affine2D().translate(10, 0)
+        for t in axes[i].get_xticklabels():
+            t.set_transform(t.get_transform() + trans)
 
-    # Format the y-axis.
-    ax.set_ylabel(y_label, fontsize=font_size)
-    ax.set_yticklabels(counts, size=font_size)
+        # Format the y-axis.
+        axes[i].set_ylabel(config['y_label'], fontsize=font_size)
+        axes[i].set_yticklabels(config['y_values'], size=font_size)
+        axes[i].set_yscale(config['y_scale'])
 
-    # Transform the y-axis to log scale.
-    if y_log_scale:
-        ax.set_yscale("log")
-
-    # Display the y-axis using nice scientific notation.
-    formatter = ScalarFormatter(useOffset=False, useMathText=True)
-    ax.yaxis.set_major_formatter(
-        FuncFormatter(lambda x, pos: "${}$".format(formatter._formatSciNotation('%1.10e' % x))))
-
-    if chart_title:
-        ax.set_title(chart_title, fontsize=font_size)
+        if config['y_scale'] == 'linear':
+            axes[i].yaxis.set_major_formatter(mticker.FormatStrFormatter('%.1e'))
+            # axes[i].yaxis.set_major_formatter(MathTextSciFormatter('%1.0e'))
 
     if save_as_img_name:
-        fig = ax.get_figure()
         plt.tight_layout()
         fig.savefig(save_as_img_name)
 
@@ -149,7 +158,33 @@ def render_lidarseg_histogram(nusc: NuScenes,
         plt.show()
 
 
-def get_lidarseg_stats(nusc: NuScenes, sort_by: str = 'count_desc') -> Tuple[List[str], List[int]]:
+class MathTextSciFormatter(mticker.Formatter):
+    """
+    # TODO
+    https://newbedev.com/show-decimal-places-and-scientific-notation-on-the-axis-of-a-matplotlib-plot
+    https://stackoverflow.com/questions/27694221/using-python-libraries-to-plot-two-horizontal-bar-charts-sharing-same-y-axis
+    """
+    def __init__(self, fmt="%1.2e"):
+        self.fmt = fmt
+
+    def __call__(self, x, pos=None):
+        s = self.fmt % x
+        decimal_point = '.'
+        positive_sign = '+'
+        tup = s.split('e')
+        significand = tup[0].rstrip(decimal_point)
+        sign = tup[1][0].replace(positive_sign, '')
+        exponent = tup[1][1:].lstrip('0')
+        if exponent:
+            exponent = '10^{%s%s}' % (sign, exponent)
+        if significand and exponent:
+            s = r'%s{\times}%s' % (significand, exponent)
+        else:
+            s = r'%s%s' % (significand, exponent)
+        return "${}$".format(s)
+
+
+def get_lidarseg_num_points_per_class(nusc: NuScenes, sort_by: str = 'count_desc') -> Dict[str, int]:
     """
     Get the number of points belonging to each class for the given nuScenes split.
     :param nusc: A NuScenes object.
@@ -158,7 +193,8 @@ def get_lidarseg_stats(nusc: NuScenes, sort_by: str = 'count_desc') -> Tuple[Lis
         - count_asc: Sort the classes by the number of points belonging to each class, in ascending order.
         - name: Sort the classes by alphabetical order.
         - index: Sort the classes by their indices.
-    :return: A list of class names and a list of the corresponding number of points for each class.
+    :return: A dictionary whose keys are the class names and values are the corresponding number of points for each
+        class.
     """
 
     # Initialize an array of zeroes, one for each class name.
@@ -173,27 +209,68 @@ def get_lidarseg_stats(nusc: NuScenes, sort_by: str = 'count_desc') -> Tuple[Lis
         for class_idx, class_count in zip(ii, indices[ii]):
             lidarseg_counts[class_idx] += class_count
 
-    lidarseg_counts_dict = dict()
+    num_points_per_class = dict()
     for i in range(len(lidarseg_counts)):
-        lidarseg_counts_dict[nusc.lidarseg_idx2name_mapping[i]] = lidarseg_counts[i]
+        num_points_per_class[nusc.lidarseg_idx2name_mapping[i]] = lidarseg_counts[i]
 
     if sort_by == 'count_desc':
-        out = sorted(lidarseg_counts_dict.items(), key=lambda item: item[1], reverse=True)
+        num_points_per_class = dict(sorted(num_points_per_class.items(), key=lambda item: item[1], reverse=True))
     elif sort_by == 'count_asc':
-        out = sorted(lidarseg_counts_dict.items(), key=lambda item: item[1])
+        num_points_per_class = dict(sorted(num_points_per_class.items(), key=lambda item: item[1]))
     elif sort_by == 'name':
-        out = sorted(lidarseg_counts_dict.items())
+        num_points_per_class = dict(sorted(num_points_per_class.items()))
     elif sort_by == 'index':
-        out = lidarseg_counts_dict.items()
+        num_points_per_class = dict(num_points_per_class.items())
     else:
         raise Exception('Error: Invalid sorting mode {}. '
                         'Only `count_desc`, `count_asc`, `name` or `index` are valid.'.format(sort_by))
 
-    # Get frequency counts of each class in the lidarseg dataset.
-    class_names = []
-    counts = []
-    for class_name, count in out:
-        class_names.append(class_name)
-        counts.append(count)
+    return num_points_per_class
 
-    return class_names, counts
+
+def get_panoptic_num_instances_per_class(nusc: NuScenes, sort_by: str = 'count_desc') -> Dict[str, int]:
+    """
+    Get the number of instances belonging to each class for the given nuScenes split.
+    :param nusc: A NuScenes object.
+    :param sort_by: How to sort the classes:
+        - count_desc: Sort the classes by the number of points belonging to each class, in descending order.
+        - count_asc: Sort the classes by the number of points belonging to each class, in ascending order.
+        - name: Sort the classes by alphabetical order.
+        - index: Sort the classes by their indices.
+    :return: A dictionary whose keys are the class names and values are the corresponding number of points for each
+        class.
+    """
+    nusc_panoptic = getattr(nusc, 'panoptic')
+
+    scene_inst_stats = dict()
+    for frame_id, record_panoptic in enumerate(nusc_panoptic):
+        panoptic_label_filename = os.path.join(nusc.dataroot, record_panoptic['filename'])
+        panoptic_label = load_bin_file(panoptic_label_filename, type='panoptic')
+        sample_token = nusc.get('sample_data', record_panoptic['sample_data_token'])['sample_token']
+        scene_token = nusc.get('sample', sample_token)['scene_token']
+        if scene_token not in scene_inst_stats:
+            scene_inst_stats[scene_token] = np.empty((0, 4), dtype=np.int32)
+        frame_cat_inst_count = get_frame_panoptic_instances(panoptic_label=panoptic_label, frame_id=frame_id)
+        scene_inst_stats[scene_token] = np.append(scene_inst_stats[scene_token], frame_cat_inst_count, axis=0)
+
+    panoptic_instances_stats = get_panoptic_instances_stats(scene_inst_stats,
+                                                            nusc.lidarseg_idx2name_mapping,
+                                                            get_hist=True)
+
+    num_instances_per_class = dict()
+    for class_name, class_instance_stats in panoptic_instances_stats['per_category_panoptic_stats'].items():
+        num_instances_per_class[class_name] = class_instance_stats['num_instances']
+
+    if sort_by == 'count_desc':
+        num_instances_per_class = dict(sorted(num_instances_per_class.items(), key=lambda item: item[1], reverse=True))
+    elif sort_by == 'count_asc':
+        num_instances_per_class = dict(sorted(num_instances_per_class.items(), key=lambda item: item[1]))
+    elif sort_by == 'name':
+        num_instances_per_class = dict(sorted(num_instances_per_class.items()))
+    elif sort_by == 'index':
+        num_instances_per_class = dict(num_instances_per_class.items())
+    else:
+        raise Exception('Error: Invalid sorting mode {}. '
+                        'Only `count_desc`, `count_asc`, `name` or `index` are valid.'.format(sort_by))
+
+    return num_instances_per_class

--- a/python-sdk/nuscenes/lidarseg/class_histogram.py
+++ b/python-sdk/nuscenes/lidarseg/class_histogram.py
@@ -150,7 +150,6 @@ def render_histogram(nusc: NuScenes,
 
         if config['y_scale'] == 'linear':
             axes[i].yaxis.set_major_formatter(mticker.FormatStrFormatter('%.1e'))
-            # axes[i].yaxis.set_major_formatter(MathTextSciFormatter('%1.0e'))
 
     if save_as_img_name:
         plt.tight_layout()


### PR DESCRIPTION
### This PR will:
-  Extend the lidarseg plot to plot histograms for both number of points and number of scan-wise instances per class; the resulting plot is as follows:
  <img src="https://user-images.githubusercontent.com/62535720/132811681-713f815f-d83b-4e39-9e15-55c5ac67ab91.png" width="750">

