### PR TITLE
Update sanity check in algo.py for tracking evaluation due to different behavior of np.unique in numpy<=1.18 and numpy>1.18

### DIFF
--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -155,22 +155,19 @@ class TrackingEvaluation(object):
         else:
             summary = pandas.concat(thresh_metrics)
 
-        thresholds = np.array(thresholds)
-
         # Get the number of thresholds which were not achieved (i.e. nan).
-        unachieved_thresholds = thresholds[np.isnan(thresholds)]
+        unachieved_thresholds = [t for t in thresholds if np.isnan(t)]
         num_unachieved_thresholds = len(unachieved_thresholds)
 
         # Get the number of thresholds which were achieved (i.e. not nan).
-        achieved_thresholds = thresholds[~np.isnan(thresholds)]
-        num_duplicate_thresholds = len(achieved_thresholds) - len(np.unique(achieved_thresholds))
+        valid_thresholds = [t for t in thresholds if not np.isnan(t)]
+        assert valid_thresholds == sorted(valid_thresholds)
+        num_duplicate_thresholds = len(valid_thresholds) - len(np.unique(valid_thresholds))
 
         # Sanity check.
         assert num_unachieved_thresholds + num_duplicate_thresholds + len(thresh_metrics) == self.num_thresholds
 
         # Figure out how many times each threshold should be repeated.
-        valid_thresholds = [t for t in thresholds if not np.isnan(t)]
-        assert valid_thresholds == sorted(valid_thresholds)
         rep_counts = [np.sum(thresholds == t) for t in np.unique(valid_thresholds)]
 
         # Store all traditional metrics.

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -201,7 +201,7 @@ class TrackingEvaluation(object):
 
                 # Pad values with nans for unachieved recall thresholds.
                 all_values = [np.nan] * unachieved_thresholds
-                all_values.append(values)
+                np.append(all_values, values)
 
             assert len(all_values) == TrackingMetricData.nelem
             md.set_metric(metric_name, all_values)

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -155,10 +155,18 @@ class TrackingEvaluation(object):
         else:
             summary = pandas.concat(thresh_metrics)
 
-        # Sanity checks.
-        unachieved_thresholds = np.sum(np.isnan(thresholds))
-        duplicate_thresholds = len(thresholds) - len(np.unique(thresholds))
-        assert unachieved_thresholds + duplicate_thresholds + len(thresh_metrics) == self.num_thresholds
+        thresholds = np.array(thresholds)
+
+        # Get the number of thresholds which were not achieved (i.e. nan).
+        unachieved_thresholds = thresholds[np.isnan(thresholds)]
+        num_unachieved_thresholds = len(unachieved_thresholds)
+
+        # Get the number of thresholds which were achieved (i.e. not nan).
+        achieved_thresholds = thresholds[~np.isnan(thresholds)]
+        num_duplicate_thresholds = len(achieved_thresholds) - len(np.unique(achieved_thresholds))
+
+        # Sanity check.
+        assert num_unachieved_thresholds + num_duplicate_thresholds + len(thresh_metrics) == self.num_thresholds
 
         # Figure out how many times each threshold should be repeated.
         valid_thresholds = [t for t in thresholds if not np.isnan(t)]

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -201,7 +201,7 @@ class TrackingEvaluation(object):
 
                 # Pad values with nans for unachieved recall thresholds.
                 all_values = [np.nan] * unachieved_thresholds
-                np.append(all_values, values)
+                all_values = np.append(all_values, values)
 
             assert len(all_values) == TrackingMetricData.nelem
             md.set_metric(metric_name, all_values)

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -156,11 +156,11 @@ class TrackingEvaluation(object):
             summary = pandas.concat(thresh_metrics)
 
         # Get the number of thresholds which were not achieved (i.e. nan).
-        unachieved_thresholds = [t for t in thresholds if np.isnan(t)]
+        unachieved_thresholds = np.array([t for t in thresholds if np.isnan(t)])
         num_unachieved_thresholds = len(unachieved_thresholds)
 
         # Get the number of thresholds which were achieved (i.e. not nan).
-        valid_thresholds = [t for t in thresholds if not np.isnan(t)]
+        valid_thresholds = np.array([t for t in thresholds if not np.isnan(t)])
         assert valid_thresholds == sorted(valid_thresholds)
         num_duplicate_thresholds = len(valid_thresholds) - len(np.unique(valid_thresholds))
 

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -160,7 +160,7 @@ class TrackingEvaluation(object):
         num_unachieved_thresholds = len(unachieved_thresholds)
 
         # Get the number of thresholds which were achieved (i.e. not nan).
-        valid_thresholds = np.array([t for t in thresholds if not np.isnan(t)])
+        valid_thresholds = [t for t in thresholds if not np.isnan(t)]
         assert valid_thresholds == sorted(valid_thresholds)
         num_duplicate_thresholds = len(valid_thresholds) - len(np.unique(valid_thresholds))
 

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -190,7 +190,7 @@ class TrackingEvaluation(object):
                     else:
                         raise NotImplementedError
 
-                all_values = [worst] * TrackingMetricData.nelem
+                all_values = list([worst] * TrackingMetricData.nelem)
             else:
                 values = summary.get(mot_name).values
                 assert np.all(values[np.logical_not(np.isnan(values))] >= 0)
@@ -200,7 +200,7 @@ class TrackingEvaluation(object):
                 values = np.concatenate([([v] * r) for (v, r) in zip(values, rep_counts)])
 
                 # Pad values with nans for unachieved recall thresholds.
-                all_values = [np.nan] * unachieved_thresholds
+                all_values = list([np.nan] * unachieved_thresholds)
                 all_values.extend(values)
 
             assert len(all_values) == TrackingMetricData.nelem

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -190,7 +190,7 @@ class TrackingEvaluation(object):
                     else:
                         raise NotImplementedError
 
-                all_values = list([worst] * TrackingMetricData.nelem)
+                all_values = [worst] * TrackingMetricData.nelem
             else:
                 values = summary.get(mot_name).values
                 assert np.all(values[np.logical_not(np.isnan(values))] >= 0)
@@ -200,8 +200,8 @@ class TrackingEvaluation(object):
                 values = np.concatenate([([v] * r) for (v, r) in zip(values, rep_counts)])
 
                 # Pad values with nans for unachieved recall thresholds.
-                all_values = list([np.nan] * unachieved_thresholds)
-                all_values.extend(values)
+                all_values = [np.nan] * unachieved_thresholds
+                all_values.append(values)
 
             assert len(all_values) == TrackingMetricData.nelem
             md.set_metric(metric_name, all_values)


### PR DESCRIPTION
### This PR will:
- Update the sanity check in algo.py for tracking evaluation due to different behavior of `np.unique` in `numpy<=1.18` and `numpy>1.1`. This should close #700  and #717