### PR TITLE
add ReLU activation function after each linear layer in CoverNet model

### DIFF
--- a/python-sdk/nuscenes/prediction/models/covernet.py
+++ b/python-sdk/nuscenes/prediction/models/covernet.py
@@ -46,7 +46,7 @@ class CoverNet(nn.Module):
                          for in_dim, out_dim in zip(n_hidden_layers[:-1], n_hidden_layers[1:])]
 
         self.head = nn.ModuleList(linear_layers)
-		self.relu = nn.ReLU()
+        self.relu = nn.ReLU()
 
     def forward(self, image_tensor: torch.Tensor,
                 agent_state_vector: torch.Tensor) -> torch.Tensor:

--- a/python-sdk/nuscenes/prediction/models/covernet.py
+++ b/python-sdk/nuscenes/prediction/models/covernet.py
@@ -46,6 +46,7 @@ class CoverNet(nn.Module):
                          for in_dim, out_dim in zip(n_hidden_layers[:-1], n_hidden_layers[1:])]
 
         self.head = nn.ModuleList(linear_layers)
+		self.relu = nn.ReLU()
 
     def forward(self, image_tensor: torch.Tensor,
                 agent_state_vector: torch.Tensor) -> torch.Tensor:
@@ -60,7 +61,7 @@ class CoverNet(nn.Module):
         logits = torch.cat([backbone_features, agent_state_vector], dim=1)
 
         for linear in self.head:
-            logits = linear(logits)
+            logits = self.relu(linear(logits))
 
         return logits
 


### PR DESCRIPTION
After discussing this issue with [Erik Wolff](https://github.com/emwolff), he asked me to create a pull request with this slight change in order to add a non-linearity to the provided CoverNet model.