### PR TITLE
Pass dataroot to get_prediction_challenge_split() in baseline_model_inference

### DIFF
--- a/python-sdk/nuscenes/eval/prediction/baseline_model_inference.py
+++ b/python-sdk/nuscenes/eval/prediction/baseline_model_inference.py
@@ -27,7 +27,7 @@ def main(version: str, data_root: str,
 
     nusc = NuScenes(version=version, dataroot=data_root)
     helper = PredictHelper(nusc)
-    dataset = get_prediction_challenge_split(split_name)
+    dataset = get_prediction_challenge_split(split_name, dataroot=data_root)
     config = load_prediction_config(helper, config_name)
     oracle = PhysicsOracle(config.seconds, helper)
     cv_heading = ConstantVelocityHeading(config.seconds, helper)


### PR DESCRIPTION
The data_root parameter is not passed when calling get_prediction_challenge_split().  
This PR does:
- Pass data_root to get_prediction_challenge_split() in [`baseline_model_inference.py`](https://github.com/nutonomy/nuscenes-devkit/pull/761/commits/4a7a96dee1e41155468de4fd8861eed79e4d9831#diff-19125fb7c15589b7e7d1973a99d008d04ff246c313e0b6e9aebaee9c14bb38ff)