### PR TITLE
Specify version for matplotlib and shapely in requirements_base.txt

### DIFF
--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -2,12 +2,12 @@ cachetools
 descartes
 fire
 jupyter
-matplotlib
+matplotlib<=3.5.2
 numpy
 opencv-python
 Pillow>6.2.1
 pyquaternion>=0.9.5
 scikit-learn
 scipy
-Shapely
+Shapely<=1.8.5
 tqdm


### PR DESCRIPTION
Specify version for `matplotlib` and `shapely` in `requirements_base.txt`

This should address various issues, including #870, #863 and #861