### PR TITLE
Update nuscenes.py

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -299,7 +299,7 @@ class NuScenes:
                 box.translate(-np.array(cs_record['translation']))
                 box.rotate(Quaternion(cs_record['rotation']).inverse)
 
-            if sensor_record['modality'] == 'camera' and not \
+            if not use_flat_vehicle_coordinates and sensor_record['modality'] == 'camera' and not \
                     box_in_image(box, cam_intrinsic, imsize, vis_level=box_vis_level):
                 continue
 


### PR DESCRIPTION
Checking for camera projections when

 use_flat_vehicle_coordinates ==  True

makes no sense since the obects are not projected into camera frame (but in another flat_vehicle_coordinate -frame)