### PR TITLE
Update setup.py license to match LICENSE.txt

### DIFF
--- a/setup/setup.py
+++ b/setup/setup.py
@@ -59,5 +59,5 @@ setuptools.setup(
         'Operating System :: OS Independent',
         'License :: Free for non-commercial use'
     ],
-    license='cc-by-nc-sa-4.0'
+    license='Apache-2.0'
 )


### PR DESCRIPTION
The LICENSE.txt file specifies Apache-2.0 as the license, but setup.py says it's cc-by-nc-sa-4.0. This updates setup.py to match the LICENSE.