### PR TITLE
Improve runtime dependencies 

### DIFF
--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -1,13 +1,12 @@
 cachetools
 descartes
 fire
-jupyter
-matplotlib<=3.5.2
+matplotlib<3.6.0
 numpy>=1.22.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1
 pyquaternion>=0.9.5
 scikit-learn
 scipy
-Shapely<=1.8.5
+Shapely<2.0.0
 tqdm

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -39,7 +39,7 @@ packages = [p for p in packages if not p.endswith('__pycache__')]
 
 setuptools.setup(
     name='nuscenes-devkit',
-    version='1.1.10',
+    version='1.1.11',
     author='Holger Caesar, Oscar Beijbom, Qiang Xu, Varun Bankiti, Alex H. Lang, Sourabh Vora, Venice Erin Liong, '
            'Sergi Widjaja, Kiwoo Shin, Caglayan Dicle, Freddy Boulton, Whye Kit Fong, Asha Asvathaman, Lubing Zhou '
            'et al.',


### PR DESCRIPTION
Hello good afternoon thanks for your work in your project. 

We are having problem in our build system due to `nuscenes-devkit` pulling some unnecessary runtime dependencies. 

In particular we have found `jupyter` being particularly problematic. 

In this PR I'm doing the following:
- Set matplotlib <3.6.0 (the breaking change that caused [this issue](https://github.com/nutonomy/nuscenes-devkit/issues/861 was introduced in 3.6.0) 
- Set Shapely <2.0.0
- Remove `jupyter` as it is not a necessary runtime deps. 