### PR TITLE
fix loop where ann_count would not count the annotations in the last sample

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -794,10 +794,11 @@ class NuScenesExplorer:
 
         def ann_count(record):
             count = 0
-            sample = self.nusc.get('sample', record['first_sample_token'])
-            while not sample['next'] == "":
+            next_sample_token = record['first_sample_token']
+            while next_sample_token:
+                sample = self.nusc.get('sample', next_sample_token)
                 count += len(sample['anns'])
-                sample = self.nusc.get('sample', sample['next'])
+                next_sample_token = sample["next"]
             return count
 
         recs = [(self.nusc.get('sample', record['first_sample_token'])['timestamp'], record) for record in


### PR DESCRIPTION
This MR fixes the while loop in ann_count. The problem was that if there is only one sample in the scene, the loop conditions is never met. Moreover, the loop condition will always be False before the annotations in the last sample in the scene are added to the count. 