### PR TITLE
Feature/python312

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -1023,9 +1023,9 @@ class NuScenesExplorer:
         if ax is None:
             fig, ax = plt.subplots(1, 1, figsize=(9, 16))
             if lidarseg_preds_bin_path:
-                fig.canvas.set_window_title(sample_token + '(predictions)')
+                fig.canvas.manager.set_window_title(sample_token + '(predictions)')
             else:
-                fig.canvas.set_window_title(sample_token)
+                fig.canvas.manager.set_window_title(sample_token)
         else:  # Set title on if rendering as part of render_sample.
             ax.set_title(camera_channel)
         ax.imshow(im)

--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -1,12 +1,12 @@
 cachetools
 descartes
 fire
-matplotlib<3.6.0
-numpy>=1.22.0
+matplotlib
+numpy>=1.22.0,<2.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1
 pyquaternion>=0.9.5
 scikit-learn
 scipy
-Shapely<2.0.0
+Shapely~=2.0.3
 tqdm


### PR DESCRIPTION
This PR adds support for python 3.12 by modifying some of the requirements:

- matplotlib: removed the `<3.6.0` restriction as this version is not compatible with python 3.12
- shapely: removed the `<2.0.0` restriction as this version is not compatible with python 3.12
- numpy: added a <2.0 restriction, since without it I was not able to install the package with python 3.8 (not sure why it tried to install it at all, seems that the 2.0.x versions are still in beta)

I ran the tests successfully with the changes and was also able to execute the jupyter notebooks without any issues. There might still be code in this repository that is not covered by either jupyter notebooks or test cases which is incompatible, but at least it's possible to install the nuscenes-devkit package via python3.12 now and use the majority of the features.