### PR TITLE
Add iou_complement  as a configurable alternative distance function to center_distance (for detection and tracking evaluation)

### DIFF
--- a/python-sdk/nuscenes/eval/detection/data_classes.py
+++ b/python-sdk/nuscenes/eval/detection/data_classes.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Tuple
 import numpy as np
 
 from nuscenes.eval.common.data_classes import MetricData, EvalBox
-from nuscenes.eval.common.utils import center_distance
+from nuscenes.eval.common.utils import center_distance, iou_complement
 from nuscenes.eval.detection.constants import DETECTION_NAMES, ATTRIBUTE_NAMES, TP_METRICS
 
 
@@ -74,6 +74,8 @@ class DetectionConfig:
         """ Return the distance function corresponding to the dist_fcn string. """
         if self.dist_fcn == 'center_distance':
             return center_distance
+        elif self.dist_fcn == "iou_complement":
+            return iou_complement
         else:
             raise Exception('Error: Unknown distance function %s!' % self.dist_fcn)
 

--- a/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_evaluate.py
@@ -149,5 +149,16 @@ class TestMain(unittest.TestCase):
         # 10. Score = 0.19449091580477748. Changed to use v1.0 mini_val split, and the equal mini_custom_val split.
         self.assertAlmostEqual(metrics.nd_score, 0.19449091580477748)
 
+        # Evaluate again but use the iou_complement distance function
+        # 1. Score = 0.16651633528966858. Measured on forked repo sbarkby/nuscenes-devkit April 22nd 2024.
+        cfg.dist_fcn = "iou_complement"
+        cfg.dist_ths = [0,0.999999]
+        cfg.dist_th_tp = 0.999999
+
+        nusc_eval = DetectionEval(nusc, cfg, self.res_mockup, eval_set=eval_split, output_dir=self.res_eval_folder,
+                                  verbose=False)
+        metrics, md_list = nusc_eval.evaluate()
+        self.assertAlmostEqual(metrics.nd_score, 0.16651633528966858)
+
 if __name__ == '__main__':
     unittest.main()

--- a/python-sdk/nuscenes/eval/detection/tests/test_utils.py
+++ b/python-sdk/nuscenes/eval/detection/tests/test_utils.py
@@ -7,8 +7,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from pyquaternion import Quaternion
 
-from nuscenes.eval.common.utils import attr_acc, scale_iou, yaw_diff, angle_diff, center_distance, velocity_l2, \
-    cummean
+from nuscenes.eval.common.utils import attr_acc, scale_iou, yaw_diff, angle_diff, iou_complement, center_distance, \
+    velocity_l2, cummean
 from nuscenes.eval.detection.data_classes import DetectionBox
 
 
@@ -127,6 +127,19 @@ class TestEval(unittest.TestCase):
         b = 180.0 + 360*200
         period = 360
         self.assertAlmostEqual(rad(180), abs(angle_diff(rad(a), rad(b), rad(period))))
+
+    def test_iou_complement_no_overlap(self):
+        # Two boxes specified, no overlap
+        sa = DetectionBox(translation=(1.0, 0.0, 1.0), size=(2,1,1))
+        sr = DetectionBox(translation=(3.5, 0.0, 1.0), size=(3,1,2))
+        self.assertAlmostEqual(iou_complement(sa, sr), 1.0)
+
+    def test_iou_complement_overlap(self):
+        # Two boxes specified, one rotated by 90 degrees in z axis, should attain 25% overlap
+        sa = DetectionBox(rotation=(0,0,0,0), translation=(1.0, 0.5, 2.0), size=(2,1,1))
+        sr = DetectionBox(rotation=(0.70710678118,0,0,0.70710678118),
+                          translation=(0.5, 1.5, 1), size=(3,1,2))
+        self.assertAlmostEqual(iou_complement(sa, sr), 0.75)
 
     def test_center_distance(self):
         """Test for center_distance()."""

--- a/python-sdk/nuscenes/eval/tracking/algo.py
+++ b/python-sdk/nuscenes/eval/tracking/algo.py
@@ -23,6 +23,7 @@ try:
 except ModuleNotFoundError:
     raise unittest.SkipTest('Skipping test as pandas was not found!')
 
+from nuscenes.eval.common.utils import iou_complement
 from nuscenes.eval.tracking.constants import MOT_METRIC_MAP, TRACKING_METRICS
 from nuscenes.eval.tracking.data_classes import TrackingBox, TrackingMetricData
 from nuscenes.eval.tracking.mot import MOTAccumulatorCustom
@@ -257,13 +258,19 @@ class TrackingEvaluation(object):
 
                 # Calculate distances.
                 # Note that the distance function is hard-coded to achieve significant speedups via vectorization.
-                assert self.dist_fcn.__name__ == 'center_distance'
                 if len(frame_gt) == 0 or len(frame_pred) == 0:
                     distances = np.ones((0, 0))
-                else:
+                elif self.dist_fcn.__name__ == 'center_distance':
                     gt_boxes = np.array([b.translation[:2] for b in frame_gt])
                     pred_boxes = np.array([b.translation[:2] for b in frame_pred])
                     distances = sklearn.metrics.pairwise.euclidean_distances(gt_boxes, pred_boxes)
+                elif self.dist_fcn.__name__ == 'iou_complement':
+                    distances = np.zeros((len(frame_gt),len(frame_pred)))
+                    for i in range(len(frame_gt)):
+                        for j in range(len(frame_pred)):
+                             distances[i,j] = iou_complement(frame_gt[i],frame_pred[j])
+                else:
+                    raise Exception('Error: Unknown distance function %s!' % self.dist_fcn.__name__)
 
                 # Distances that are larger than the threshold won't be associated.
                 assert len(distances) == 0 or not np.all(np.isnan(distances))

--- a/python-sdk/nuscenes/eval/tracking/data_classes.py
+++ b/python-sdk/nuscenes/eval/tracking/data_classes.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 from nuscenes.eval.common.data_classes import MetricData, EvalBox
-from nuscenes.eval.common.utils import center_distance
+from nuscenes.eval.common.utils import center_distance, iou_complement
 from nuscenes.eval.tracking.constants import TRACKING_METRICS, AMOT_METRICS
 
 
@@ -86,6 +86,8 @@ class TrackingConfig:
         """ Return the distance function corresponding to the dist_fcn string. """
         if self.dist_fcn == 'center_distance':
             return center_distance
+        elif self.dist_fcn == "iou_complement":
+            return iou_complement
         else:
             raise Exception('Error: Unknown distance function %s!' % self.dist_fcn)
 

--- a/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
@@ -19,7 +19,6 @@ class TestAlgo(unittest.TestCase):
         class_name = 'car'
         box = TrackingBox(translation=(0, 0, 0), tracking_id='ta', tracking_name=class_name,
                           tracking_score=0.5)
-        box.size = [3,1,1]
         timestamp_boxes_gt = {
             0: [copy.deepcopy(box)],
             1: [copy.deepcopy(box)],

--- a/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_algo.py
@@ -19,6 +19,7 @@ class TestAlgo(unittest.TestCase):
         class_name = 'car'
         box = TrackingBox(translation=(0, 0, 0), tracking_id='ta', tracking_name=class_name,
                           tracking_score=0.5)
+        box.size = [3,1,1]
         timestamp_boxes_gt = {
             0: [copy.deepcopy(box)],
             1: [copy.deepcopy(box)],

--- a/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
+++ b/python-sdk/nuscenes/eval/tracking/tests/test_evaluate.py
@@ -31,6 +31,7 @@ class TestMain(unittest.TestCase):
                 "mini_custom_train": ["scene-0061", "scene-0553"],
                 "mini_custom_val": ["scene-0103", "scene-0916"]
             }, f, indent=2)
+
     def tearDown(self):
         if os.path.exists(self.res_mockup):
             os.remove(self.res_mockup)
@@ -88,7 +89,7 @@ class TestMain(unittest.TestCase):
         scenes_of_eval_split : List[str] = get_scenes_of_split(split_name=split, nusc=nusc)
         val_samples = []
         for sample in nusc.sample:
-            if nusc.get('scene', sample['scene_token'])['name'] in splits[split]:
+            if nusc.get('scene', sample['scene_token'])['name'] in scenes_of_eval_split:
                 val_samples.append(sample)
 
         # Prepare results.
@@ -242,6 +243,8 @@ class TestMain(unittest.TestCase):
         :param eval_set: Which set to evaluate on.
         :param render_curves: Whether to render stats curves to disk.
         """
+        mock__get_custom_splits_file_path.return_value = self.splits_file_mockup
+
         # Run the evaluation without errors.
         metrics = self.basic_test(eval_set, add_errors=False, render_curves=render_curves,
                                   dist_fcn='center_distance', dist_th_tp=2.0)


### PR DESCRIPTION
This PR introduces the Intersection Over Union  complement (1.0 - IOU) as an alternative distance function for determining matches and the calculation of metrics, such as MOTP. The use of this distance function has been made configurable in the detection_cvpr_2019.json and tracking_nips_2019.json config files for detection and tracking evaluation respectively. Fortunately the codebase was already setup to cater for alternative distance functions, so the coding change proposed here is minimal.

Also note that this PR poses no change to the default operation of the evaluator, it will continue to use "center_distance" as it's distance function by default.