### PR TITLE
Support matplotlib >=3.6.0

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -8,27 +8,32 @@ import os.path as osp
 import sys
 import time
 from datetime import datetime
-from typing import Tuple, List, Iterable
+from typing import Iterable, List, Tuple
 
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import sklearn.metrics
-from PIL import Image
 from matplotlib import rcParams
 from matplotlib.axes import Axes
+from nuscenes.lidarseg.lidarseg_utils import (colormap_to_colors,
+                                              create_lidarseg_legend,
+                                              get_labels_in_coloring,
+                                              get_stats, paint_points_label,
+                                              plt_to_cv2)
+from nuscenes.panoptic.panoptic_utils import (get_frame_panoptic_instances,
+                                              get_panoptic_instances_stats,
+                                              paint_panop_points_label,
+                                              stuff_cat_ids)
+from nuscenes.utils.color_map import get_colormap
+from nuscenes.utils.data_classes import Box, LidarPointCloud, RadarPointCloud
+from nuscenes.utils.data_io import load_bin_file, panoptic_to_lidarseg
+from nuscenes.utils.geometry_utils import (BoxVisibility, box_in_image,
+                                           transform_matrix, view_points)
+from nuscenes.utils.map_mask import MapMask
+from PIL import Image
 from pyquaternion import Quaternion
 from tqdm import tqdm
-
-from nuscenes.lidarseg.lidarseg_utils import colormap_to_colors, plt_to_cv2, get_stats, \
-    get_labels_in_coloring, create_lidarseg_legend, paint_points_label
-from nuscenes.panoptic.panoptic_utils import paint_panop_points_label, stuff_cat_ids, get_frame_panoptic_instances,\
-    get_panoptic_instances_stats
-from nuscenes.utils.data_classes import LidarPointCloud, RadarPointCloud, Box
-from nuscenes.utils.data_io import load_bin_file, panoptic_to_lidarseg
-from nuscenes.utils.geometry_utils import view_points, box_in_image, BoxVisibility, transform_matrix
-from nuscenes.utils.map_mask import MapMask
-from nuscenes.utils.color_map import get_colormap
 
 PYTHON_VERSION = sys.version_info[0]
 
@@ -1023,9 +1028,9 @@ class NuScenesExplorer:
         if ax is None:
             fig, ax = plt.subplots(1, 1, figsize=(9, 16))
             if lidarseg_preds_bin_path:
-                fig.canvas.set_window_title(sample_token + '(predictions)')
+                fig.canvas.manager.set_window_title(sample_token + '(predictions)')
             else:
-                fig.canvas.set_window_title(sample_token)
+                fig.canvas.manager.set_window_title(sample_token)
         else:  # Set title on if rendering as part of render_sample.
             ax.set_title(camera_channel)
         ax.imshow(im)

--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -1,13 +1,12 @@
 cachetools
 descartes
 fire
-jupyter
-matplotlib<=3.5.2
+matplotlib<3.6.0
 numpy>=1.22.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1
 pyquaternion>=0.9.5
 scikit-learn
 scipy
-Shapely<=1.8.5
+Shapely<2.0.0
 tqdm

--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -1,7 +1,7 @@
 cachetools
 descartes
 fire
-matplotlib>=3.6.0
+matplotlib>3.4.0
 numpy>=1.22.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1

--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -1,7 +1,7 @@
 cachetools
 descartes
 fire
-matplotlib<3.6.0
+matplotlib>=3.6.0
 numpy>=1.22.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -39,7 +39,7 @@ packages = [p for p in packages if not p.endswith('__pycache__')]
 
 setuptools.setup(
     name='nuscenes-devkit',
-    version='1.1.10',
+    version='1.1.11',
     author='Holger Caesar, Oscar Beijbom, Qiang Xu, Varun Bankiti, Alex H. Lang, Sourabh Vora, Venice Erin Liong, '
            'Sergi Widjaja, Kiwoo Shin, Caglayan Dicle, Freddy Boulton, Whye Kit Fong, Asha Asvathaman, Lubing Zhou '
            'et al.',


### PR DESCRIPTION
`nuscene-devkit` only supports matplotlib < 3.6.0. I have tried to apply the suggestion from [this](https://github.com/nutonomy/nuscenes-devkit/issues/861#issuecomment-2031529615) comment and see if this works with matplotlib >= 3.4.0 (I'm mostlry interested in 3.6.0+ due to [this](https://github.com/matplotlib/matplotlib/issues/23074) issue) 

The change rename `fig.canvas.set_window_title` to `fig.canvas.manager.set_window_title`

I still need to build a PR and test it. 