### PR TITLE
Prevent numpy >= 2.0.0

### DIFF
--- a/setup/requirements/requirements_base.txt
+++ b/setup/requirements/requirements_base.txt
@@ -2,7 +2,7 @@ cachetools
 descartes
 fire
 matplotlib<3.6.0
-numpy>=1.22.0
+numpy>=1.22.0,<2.0.0
 opencv-python>=4.5.4.58
 Pillow>6.2.1
 pyquaternion>=0.9.5


### PR DESCRIPTION
numpy 2.0.0 comes with some bigger changes that I think the nuscenes-devkit is not prepared for (there are even problems for larger minor versions within numpy 1 https://github.com/nutonomy/nuscenes-devkit/issues/1055)

So I believe, the best we can do right now to enable a smooth installation of requirements is to at least prevent numpy 2