### PR TITLE
fix nusc.list_scenes() for duplicate timestamps

### DIFF
--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -800,7 +800,7 @@ class NuScenesExplorer:
                 sample = self.nusc.get('sample', sample['next'])
             return count
 
-        recs = [(self.nusc.get('sample', record['first_sample_token'])['timestamp'], record) for record in
+        recs = [(self.nusc.get('sample', record['first_sample_token'])['timestamp'], record['token'], record) for record in
                 self.nusc.scene]
 
         for start_time, record in sorted(recs):

--- a/python-sdk/nuscenes/nuscenes.py
+++ b/python-sdk/nuscenes/nuscenes.py
@@ -800,10 +800,10 @@ class NuScenesExplorer:
                 sample = self.nusc.get('sample', sample['next'])
             return count
 
-        recs = [(self.nusc.get('sample', record['first_sample_token'])['timestamp'], record['token'], record) for record in
-                self.nusc.scene]
+        recs = [(self.nusc.get('sample', record['first_sample_token'])['timestamp'], record['token'], record)
+                for record in self.nusc.scene]
 
-        for start_time, record in sorted(recs):
+        for start_time, _, record in sorted(recs):
             start_time = self.nusc.get('sample', record['first_sample_token'])['timestamp'] / 1000000
             length_time = self.nusc.get('sample', record['last_sample_token'])['timestamp'] / 1000000 - start_time
             location = self.nusc.get('log', record['log_token'])['location']


### PR DESCRIPTION
Candidate fix for #1142. This ensures sorting will always work even if there are duplicate timestamps, otherwise trying to compare two `record`s causes a `ValueError` because dicts are not orderable.