### PR TITLE
matplotlib style

### DIFF
--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -29,7 +29,7 @@ from nuscenes.nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import view_points
 
 # Recommended style to use as the plots will show grids.
-plt.style.use('seaborn-v0_8-whitegrid')
+plt.style.use('seaborn-v0_8-white')
 
 # Define a map geometry type for polygons and lines.
 Geometry = Union[Polygon, LineString]

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -29,7 +29,7 @@ from nuscenes.nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import view_points
 
 # Recommended style to use as the plots will show grids.
-plt.style.use('seaborn-v0_8-white')
+plt.style.use('seaborn-v0_8-whitegrid')
 
 # Define a map geometry type for polygons and lines.
 Geometry = Union[Polygon, LineString]

--- a/python-sdk/nuscenes/map_expansion/map_api.py
+++ b/python-sdk/nuscenes/map_expansion/map_api.py
@@ -29,7 +29,7 @@ from nuscenes.nuscenes import NuScenes
 from nuscenes.utils.geometry_utils import view_points
 
 # Recommended style to use as the plots will show grids.
-plt.style.use('seaborn-whitegrid')
+plt.style.use('seaborn-v0_8-whitegrid')
 
 # Define a map geometry type for polygons and lines.
 Geometry = Union[Polygon, LineString]


### PR DESCRIPTION
The upgraded matplotlib style does not contain "seaborn-whitegrid". It has been deprecated.